### PR TITLE
iosapp: update swift-navigation package for latest swift/xcode compat

### DIFF
--- a/swift/iosapp/Gertrude-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift/iosapp/Gertrude-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
-        "version" : "2.3.0"
+        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
+        "version" : "2.6.0"
       }
     },
     {

--- a/swift/iosapp/lib-ios/Package.resolved
+++ b/swift/iosapp/lib-ios/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "db6bc9dbfed001f21e6728fd36413d9342c235b4",
-        "version" : "2.3.0"
+        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
+        "version" : "2.6.0"
       }
     },
     {


### PR DESCRIPTION
in spiking out a research poc, realized i couldn't build the iosapp. probably from updating to xcode 26.x or swift 6.2.1, was a compile error in a pointfree lib, this fixes it.