### PR TITLE
api: skip inserting duplicate rating snapshots

### DIFF
--- a/swift/api/Sources/Api/Models/AppStore/RatingSnapshot.swift
+++ b/swift/api/Sources/Api/Models/AppStore/RatingSnapshot.swift
@@ -7,7 +7,7 @@ extension AppStore {
     var averageRating: Double
     var totalCount: Int
     var reviewCount: Int
-    var createdAt: Date = .init()
+    var createdAt = Date()
 
     init(
       id: Id = .init(),

--- a/swift/api/Sources/Api/Services/Jobs/AppStoreSyncJob.swift
+++ b/swift/api/Sources/Api/Services/Jobs/AppStoreSyncJob.swift
@@ -59,7 +59,7 @@ struct AppStoreSyncJob: AsyncScheduledJob {
 
   // app store connect api doesn't give great data about rating-only submissions
   // only aggregate data, so we store snapshots in order to infer events
-  private func syncRatings(for app: AppStore.GertrudeApp) async {
+  func syncRatings(for app: AppStore.GertrudeApp) async {
     do {
       let ratings = try await self.appStoreConnect.fetchRatings(app)
 
@@ -71,6 +71,16 @@ struct AppStoreSyncJob: AsyncScheduledJob {
         .where(.app == app.rawValue)
         .orderBy(.createdAt, .desc)
         .first(in: self.db)
+
+      let snapshotValuesUnchanged = prevSnapshot.map { prev in
+        prev.averageRating == ratings.averageUserRating
+          && prev.totalCount == ratings.userRatingCount
+          && prev.reviewCount == reviewCount
+      } ?? false
+
+      if snapshotValuesUnchanged {
+        return
+      }
 
       let newSnapshot = try await self.db.create(AppStore.RatingSnapshot(
         app: app,

--- a/swift/api/Tests/ApiTests/AppStoreSyncJobTests.swift
+++ b/swift/api/Tests/ApiTests/AppStoreSyncJobTests.swift
@@ -1,0 +1,115 @@
+import Dependencies
+import DuetSQL
+import XCTest
+import XExpect
+
+@testable import Api
+
+final class AppStoreSyncJobTests: ApiTestCase, @unchecked Sendable {
+  override func setUp() async throws {
+    try await super.setUp()
+    try await self.db.delete(all: AppStore.RatingSnapshot.self)
+    try await self.db.delete(all: AppStore.Review.self)
+    try await self.db.delete(all: AppStore.RatingEvent.self)
+  }
+
+  func testUnchangedRatingsDoesNotInsertNewSnapshot() async throws {
+    let initialSnapshot = try await self.db.create(AppStore.RatingSnapshot(
+      app: .blocker,
+      averageRating: 4.5,
+      totalCount: 100,
+      reviewCount: 0,
+    ))
+
+    try await withDependencies {
+      $0.db = self.db
+      $0.env = .testValue
+      $0.slack = .mock
+      $0.appStoreConnect.fetchReviews = { _ in [] }
+      $0.appStoreConnect.fetchRatings = { _ in
+        ITunesRatings(averageUserRating: 4.5, userRatingCount: 100)
+      }
+    } operation: {
+      await AppStoreSyncJob().syncRatings(for: .blocker)
+
+      let snapshots = try await AppStore.RatingSnapshot.query()
+        .where(.app == AppStore.GertrudeApp.blocker.rawValue)
+        .all(in: self.db)
+
+      expect(snapshots.count).toEqual(1)
+      expect(snapshots[0].id).toEqual(initialSnapshot.id)
+    }
+  }
+
+  func testChangedRatingsInsertsNewSnapshot() async throws {
+    let initialSnapshot = try await self.db.create(AppStore.RatingSnapshot(
+      app: .blocker,
+      averageRating: 4.5,
+      totalCount: 100,
+      reviewCount: 0,
+    ))
+
+    try await withDependencies {
+      $0.db = self.db
+      $0.env = .testValue
+      $0.slack = .mock
+      $0.appStoreConnect.fetchReviews = { _ in [] }
+      $0.appStoreConnect.fetchRatings = { _ in
+        ITunesRatings(averageUserRating: 4.6, userRatingCount: 101)
+      }
+    } operation: {
+      await AppStoreSyncJob().syncRatings(for: .blocker)
+
+      let snapshots = try await AppStore.RatingSnapshot.query()
+        .where(.app == AppStore.GertrudeApp.blocker.rawValue)
+        .orderBy(.createdAt, .asc)
+        .all(in: self.db)
+
+      expect(snapshots.count).toEqual(2)
+      expect(snapshots[0].id).toEqual(initialSnapshot.id)
+      expect(snapshots[1].averageRating).toEqual(4.6)
+      expect(snapshots[1].totalCount).toEqual(101)
+    }
+  }
+
+  func testInfersRatingEventWhenSnapshotChanges() async throws {
+    try await self.db.create(AppStore.RatingSnapshot(
+      app: .blocker,
+      averageRating: 4.0,
+      totalCount: 10,
+      reviewCount: 5,
+    ))
+
+    for i in 0 ..< 5 {
+      try await self.db.create(AppStore.Review(
+        appleId: "review-\(i)",
+        app: .blocker,
+        rating: 4,
+        title: "Title",
+        body: "Body",
+        reviewerNickname: "User",
+        territory: "US",
+        reviewCreatedAt: .reference,
+      ))
+    }
+
+    try await withDependencies {
+      $0.db = self.db
+      $0.env = .testValue
+      $0.slack = .mock
+      $0.appStoreConnect.fetchReviews = { _ in [] }
+      $0.appStoreConnect.fetchRatings = { _ in
+        ITunesRatings(averageUserRating: 4.1, userRatingCount: 11)
+      }
+    } operation: {
+      await AppStoreSyncJob().syncRatings(for: .blocker)
+
+      let events = try await AppStore.RatingEvent.query()
+        .where(.app == AppStore.GertrudeApp.blocker.rawValue)
+        .all(in: self.db)
+
+      expect(events.count).toEqual(1)
+      expect(events[0].stars).toEqual(5)
+    }
+  }
+}


### PR DESCRIPTION
```sql
-- Delete duplicates (keeping the oldest record per unique combination)
  DELETE FROM appstore.rating_snapshots
  WHERE id IN (
    SELECT rs.id FROM appstore.rating_snapshots rs
    INNER JOIN (
      SELECT app, average_rating, total_count, review_count, MIN(created_at) AS keep_created_at
      FROM appstore.rating_snapshots
      GROUP BY app, average_rating, total_count, review_count
      HAVING COUNT(*) > 1
    ) dg ON rs.app = dg.app
      AND rs.average_rating = dg.average_rating
      AND rs.total_count = dg.total_count
      AND rs.review_count = dg.review_count
      AND rs.created_at != dg.keep_created_at
  );
```