### PR TITLE
api: fix search_path trigger to put public schema first

### DIFF
--- a/swift/api/Sources/Api/Configure/migrations.swift
+++ b/swift/api/Sources/Api/Configure/migrations.swift
@@ -62,6 +62,7 @@ extension Configure {
     app.migrations.add(DashAnnouncementKind())
     app.migrations.add(SupervisionStateBooleans())
     app.migrations.add(LoginSearchPathTrigger())
+    app.migrations.add(FixSearchPathTrigger())
   }
 }
 

--- a/swift/api/Sources/Api/Database/Migrations/057_FixSearchPathTrigger.swift
+++ b/swift/api/Sources/Api/Database/Migrations/057_FixSearchPathTrigger.swift
@@ -1,0 +1,50 @@
+import FluentSQL
+
+struct FixSearchPathTrigger: GertieMigration {
+  func up(sql: SQLDatabase) async throws {
+    try await sql.execute("""
+      CREATE OR REPLACE FUNCTION set_search_path_on_login()
+      RETURNS event_trigger
+      SECURITY DEFINER
+      LANGUAGE plpgsql AS $$
+      DECLARE
+        schema_list text;
+      BEGIN
+        SELECT 'public, ' || string_agg(schema_name, ', ' ORDER BY schema_name)
+        INTO schema_list
+        FROM information_schema.schemata
+        WHERE schema_name NOT LIKE 'pg_%'
+          AND schema_name NOT IN ('information_schema', 'public');
+        EXECUTE 'SET search_path TO ' || schema_list;
+      END;
+      $$;
+    """)
+
+    try await sql.execute("""
+      DROP TABLE IF EXISTS appstore._fluent_migrations;
+    """)
+
+    try await sql.execute("""
+      DROP TABLE IF EXISTS appstore._jobs_meta;
+    """)
+  }
+
+  func down(sql: SQLDatabase) async throws {
+    try await sql.execute("""
+      CREATE OR REPLACE FUNCTION set_search_path_on_login()
+      RETURNS event_trigger
+      SECURITY DEFINER
+      LANGUAGE plpgsql AS $$
+      DECLARE
+        schema_list text;
+      BEGIN
+        SELECT string_agg(schema_name, ', ' ORDER BY schema_name) INTO schema_list
+        FROM information_schema.schemata
+        WHERE schema_name NOT LIKE 'pg_%'
+          AND schema_name != 'information_schema';
+        EXECUTE 'SET search_path TO ' || schema_list;
+      END;
+      $$;
+    """)
+  }
+}


### PR DESCRIPTION
context: the search path trigger we installed in prev migration somehow caused vapor/fluent to start writing migration records in the `appstore` postgres schema (b/c first alphabetically), which later caused crash when running migrations, as it tried to re-run migrations already done, b/c was looking in the wrong spot. this puts `public` explicitly first, which should prevent the issue in the future and allow internal unqualified table names not found in on of our schemas to be resolved to `public`

```sql
  DROP TABLE IF EXISTS appstore._fluent_migrations;
  DROP TABLE IF EXISTS appstore._jobs_meta;

  CREATE OR REPLACE FUNCTION public.set_search_path_on_login()
  RETURNS event_trigger
  SECURITY DEFINER
  LANGUAGE plpgsql AS $$
  DECLARE
    schema_list text;
  BEGIN
    SELECT 'public, ' || string_agg(schema_name, ', ' ORDER BY schema_name)
    INTO schema_list
    FROM information_schema.schemata
    WHERE schema_name NOT LIKE 'pg_%'
      AND schema_name NOT IN ('information_schema', 'public');
    EXECUTE 'SET search_path TO ' || schema_list;
  END;
  $$;
```