### PR TITLE
2.9.2 release prep: silence noisy filter logs, ech always-block, appcast hide

### DIFF
--- a/swift/api/Sources/Api/PairQL/Dashboard/Pairs/SaveKey.swift
+++ b/swift/api/Sources/Api/PairQL/Dashboard/Pairs/SaveKey.swift
@@ -19,6 +19,15 @@ struct SaveKey: Pair {
 
 extension SaveKey: Resolver {
   static func resolve(with input: Input, in context: ParentContext) async throws -> Output {
+    if input.key.targetsCloudflareEch {
+      throw context.error(
+        id: "734da77b",
+        type: .badRequest,
+        debugMessage: "rejected key targeting cloudflare-ech.com",
+        userMessage: "Gertrude blocks cloudflare-ech.com automatically — no key needed.",
+        showContactSupport: false,
+      )
+    }
     let keychain = try await context.parent.keychain(input.keychainId, in: context.db)
     if input.isNew {
       let existingKeys = try await keychain.keys(in: context.db)
@@ -69,6 +78,16 @@ extension SaveKey: Resolver {
 }
 
 extension Gertie.Key {
+  var targetsCloudflareEch: Bool {
+    let hostname: String? = switch self {
+    case .domain(let domain, _), .anySubdomain(let domain, _): domain.string
+    case .path(let path, _): path.domain.string
+    case .domainRegex, .ipAddress, .skeleton: nil
+    }
+    guard let hostname else { return false }
+    return hostname == "cloudflare-ech.com" || hostname.hasSuffix(".cloudflare-ech.com")
+  }
+
   var simpleDescription: String {
     switch self {
     case .anySubdomain(let domain, let scope):

--- a/swift/api/Sources/Api/PairQL/MacApp/Resolvers/CheckIn_v2.swift
+++ b/swift/api/Sources/Api/PairQL/MacApp/Resolvers/CheckIn_v2.swift
@@ -9,7 +9,7 @@ extension CheckIn_v2: Resolver {
     async let browsers = Browser.query().all(in: context.db)
     async let blockedApps = context.child.blockedApps(in: context.db)
     async let keychains = loadRuleKeychains(in: context)
-    async let alwaysBlocked = loadAlwaysBlockedRules(for: context.child.id, in: context.db)
+    async let alwaysBlocked = loadAlwaysBlockedRules(in: context)
 
     let (computerUser, upgradedFrom) = try await syncComputerUser(from: input, in: context)
     slackOnUpgrade(from: input, oldVersion: upgradedFrom, in: context)
@@ -365,23 +365,23 @@ private extension CheckIn_v2 {
 // helpers
 
 func loadAlwaysBlockedRules(
-  for childId: Child.Id,
-  in db: any DuetSQL.Client,
+  in context: MacApp.ChildContext,
 ) async throws -> [BlockRule] {
   async let childGroups = ChildAlwaysBlockedGroup.query()
-    .where(.childId == childId)
-    .all(in: db)
+    .where(.childId == context.child.id)
+    .all(in: context.db)
   async let customRules = ChildAlwaysBlockedRule.query()
-    .where(.childId == childId)
-    .all(in: db)
+    .where(.childId == context.child.id)
+    .all(in: context.db)
 
   let groupIds = try await childGroups.map(\.groupId)
   let groupRules = groupIds.isEmpty ? [] : try await AlwaysBlockedRule.query()
     .where(.groupId |=| groupIds)
-    .all(in: db)
+    .all(in: context.db)
 
   let rules = try await groupRules.map(\.rule) + customRules.map(\.rule)
-  if rules.isEmpty { return [] }
+  // filtering-disabled children opted into monitoring-only, so sni enforcement is moot
+  if context.child.filteringDisabled { return rules }
   // try to prevent sni obfuscation/hiding, which interferes with hostname detection
   return rules + [.hostnameOrSubdomain(value: "cloudflare-ech.com")]
 }

--- a/swift/api/Sources/Api/PairQL/MacApp/Resolvers/LogFilterEvents.swift
+++ b/swift/api/Sources/Api/PairQL/MacApp/Resolvers/LogFilterEvents.swift
@@ -6,7 +6,16 @@ import PostgresKit
 extension LogFilterEvents: Resolver {
   static func resolve(with input: Input, in context: MacApp.ChildContext) async throws -> Output {
     let computerUser = try await context.computerUser()
-    let events = try await context.db.create(input.events.map { event, count in
+    let version = Semver(computerUser.appVersion) ?? .zero
+    let kept = input.events.filter { event, _ in
+      if droppedEventIds.contains(event.id) { return false }
+      if version < firstCleanedVersion, droppedPre292EventIds.contains(event.id) {
+        return false
+      }
+      return true
+    }
+
+    let events = try await context.db.create(kept.map { event, count in
       InterestingEvent(
         eventId: event.id,
         kind: "event",
@@ -95,6 +104,17 @@ struct IdentifiedBundleIds: CustomQueryable {
 
   var bundleId: String
 }
+
+private let firstCleanedVersion: Semver = "2.9.2"
+
+private let droppedEventIds: Set<String> = [
+  "outboundDeferredStateMissing",
+  "sawEncryptedClientHello_x100",
+]
+
+private let droppedPre292EventIds: Set<String> = [
+  "outboundBytesGapDetected",
+]
 
 private func logEventsToSlack(
   _ events: [InterestingEvent],

--- a/swift/api/Sources/Api/Routes/Appcast.swift
+++ b/swift/api/Sources/Api/Routes/Appcast.swift
@@ -4,12 +4,18 @@ import Gertie
 import Vapor
 
 enum AppcastRoute {
+  static let suppressedReleases: [String: Set<String>] = [
+    "2.9.1": ["2.9.2"],
+  ]
+
   @Sendable static func handler(_ request: Request) async throws -> Response {
     let query = try request.query.decode(AppcastQuery.self)
+    let hidden = query.requestingAppVersion.flatMap { self.suppressedReleases[$0] } ?? []
     let releases = try await request.context.db.query(Release.self)
       .orderBy(.createdAt, .desc)
       .all(in: request.context.db)
       .filter { $0.channel.isAtLeastAsStable(as: query.channel ?? .stable) }
+      .filter { !hidden.contains($0.semver) }
 
     return Response(
       headers: ["Content-Type": "application/xml"],

--- a/swift/api/Tests/ApiTests/AppcastTests.swift
+++ b/swift/api/Tests/ApiTests/AppcastTests.swift
@@ -29,6 +29,45 @@ final class AppcastTests: ApiTestCase, @unchecked Sendable {
     })
   }
 
+  func testHidesReleasesFromSpecificRequestingVersion() async throws {
+    try await self.replaceAllReleases(with: [
+      Release("2.9.0", channel: .stable, pace: nil, createdAt: .epoch),
+      Release("2.9.1", channel: .stable, pace: nil, createdAt: .epoch.advanced(by: .days(10))),
+      Release("2.9.2", channel: .stable, pace: nil, createdAt: .epoch.advanced(by: .days(20))),
+    ])
+
+    try await app.test(
+      .GET,
+      "appcast.xml?requestingAppVersion=2.9.1",
+      afterResponse: { res in
+        await expect(self.filenames(from: res)).toEqual([
+          "Gertrude.2.9.1.zip",
+          "Gertrude.2.9.0.zip",
+        ])
+      },
+    )
+
+    try await app.test(
+      .GET,
+      "appcast.xml?requestingAppVersion=2.9.0",
+      afterResponse: { res in
+        await expect(self.filenames(from: res)).toEqual([
+          "Gertrude.2.9.2.zip",
+          "Gertrude.2.9.1.zip",
+          "Gertrude.2.9.0.zip",
+        ])
+      },
+    )
+
+    try await app.test(.GET, "appcast.xml", afterResponse: { res in
+      await expect(self.filenames(from: res)).toEqual([
+        "Gertrude.2.9.2.zip",
+        "Gertrude.2.9.1.zip",
+        "Gertrude.2.9.0.zip",
+      ])
+    })
+  }
+
   // NB: async just to force selection of async overload of `app.test()`
   func filenames(from response: XCTHTTPResponse) async -> [String] {
     response.body.string.split(separator: "\n")

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/KeyResolverTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/KeyResolverTests.swift
@@ -168,6 +168,20 @@ final class KeyResolverTests: ApiTestCase, @unchecked Sendable {
     expect(matching.first?.comment).toBeNil()
   }
 
+  func testRejectsCloudflareEchKey() async throws {
+    var (input, admin) = try await prepare()
+    input.key = .anySubdomain(domain: .init(string: "cloudflare-ech.com"), scope: .unrestricted)
+
+    try await expectErrorFrom {
+      try await SaveKey.resolve(with: input, in: admin.context)
+    }.toContain("cloudflare-ech.com")
+
+    input.key = .domain(domain: .init(string: "foo.cloudflare-ech.com"), scope: .unrestricted)
+    try await expectErrorFrom {
+      try await SaveKey.resolve(with: input, in: admin.context)
+    }.toContain("cloudflare-ech.com")
+  }
+
   func testUpdateKeyRecordWithExpiration() async throws {
     var (input, admin) = try await prepare()
     let key = try await self.db.create(Key(keychainId: admin.keychain.id, key: .mock))

--- a/swift/api/Tests/ApiTests/MacappPairResolvers/CheckIn_v2ResolverTests.swift
+++ b/swift/api/Tests/ApiTests/MacappPairResolvers/CheckIn_v2ResolverTests.swift
@@ -354,7 +354,7 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
     expect(output.adminAccountStatus).toEqual(.active)
   }
 
-  func testAlwaysBlocked_NilWhenChildHasNoRules() async throws {
+  func testAlwaysBlocked_IncludesCloudflareEchRuleWhenChildHasNoAbRules() async throws {
     let child = try await self.child().withDevice()
 
     let output = try await CheckIn_v2.resolve(
@@ -362,7 +362,9 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
       in: child.context,
     )
 
-    expect(output.alwaysBlocked).toBeNil()
+    expect(output.alwaysBlocked).toEqual([
+      .hostnameOrSubdomain(value: "cloudflare-ech.com"),
+    ])
   }
 
   func testAlwaysBlocked_AppendsCloudflareEchRuleWhenNonEmpty() async throws {
@@ -381,6 +383,39 @@ final class CheckIn_v2ResolverTests: ApiTestCase, @unchecked Sendable {
     expect(output.alwaysBlocked).toEqual([
       .hostnameEquals(value: "example.com"),
       .hostnameOrSubdomain(value: "cloudflare-ech.com"),
+    ])
+  }
+
+  func testAlwaysBlocked_OmitsCloudflareEchRuleForFilteringDisabledChild() async throws {
+    let child = try await self.child(with: {
+      $0.filteringDisabled = true
+    }).withDevice()
+
+    let output = try await CheckIn_v2.resolve(
+      with: .init(appVersion: "1.0.0", filterVersion: nil),
+      in: child.context,
+    )
+
+    expect(output.alwaysBlocked).toBeNil()
+  }
+
+  func testAlwaysBlocked_FilteringDisabledChildGetsAbRulesButNoCloudflareEch() async throws {
+    let child = try await self.child(with: {
+      $0.filteringDisabled = true
+    }).withDevice()
+
+    try await self.db.create(ChildAlwaysBlockedRule(
+      childId: child.model.id,
+      rule: .hostnameEquals(value: "example.com"),
+    ))
+
+    let output = try await CheckIn_v2.resolve(
+      with: .init(appVersion: "1.0.0", filterVersion: nil),
+      in: child.context,
+    )
+
+    expect(output.alwaysBlocked).toEqual([
+      .hostnameEquals(value: "example.com"),
     ])
   }
 

--- a/swift/macapp/App/Sources/App/BlockedRequests/BlockedRequest+Mergeable.swift
+++ b/swift/macapp/App/Sources/App/BlockedRequests/BlockedRequest+Mergeable.swift
@@ -1,6 +1,11 @@
 import Core
 
 extension BlockedRequest {
+  var hiddenFromParent: Bool {
+    guard let hostname else { return false }
+    return hostname == "cloudflare-ech.com" || hostname.hasSuffix(".cloudflare-ech.com")
+  }
+
   func mergeable(with newer: BlockedRequest) -> Bool {
     if self.app.bundleId.droppingDotPrefix != newer.app.bundleId.droppingDotPrefix {
       return false

--- a/swift/macapp/App/Sources/App/BlockedRequests/BlockedRequestsFeature.swift
+++ b/swift/macapp/App/Sources/App/BlockedRequests/BlockedRequestsFeature.swift
@@ -167,6 +167,9 @@ extension BlockedRequestsFeature.RootReducer {
       }
 
     case .xpc(.receivedExtensionMessage(.blockedRequest(let newReq))):
+      if newReq.hiddenFromParent {
+        return .none
+      }
       let recent = state.blockedRequests.requests.suffix(15)
       if !recent.contains(where: { existing in existing.mergeable(with: newReq) }) {
         state.blockedRequests.requests.append(newReq)

--- a/swift/macapp/App/Sources/Core/OutboundDataParser.swift
+++ b/swift/macapp/App/Sources/Core/OutboundDataParser.swift
@@ -10,38 +10,6 @@ public enum OutboundDataParser {
     case malformed
   }
 
-  public static func containsEncryptedClientHello(_ data: Data) -> Bool {
-    guard let firstByte = data.first,
-          firstByte == 0x16,
-          data.count >= 5,
-          data[1] == 0x03
-    else {
-      return false
-    }
-
-    let recordLength = Int(data[3]) << 8 | Int(data[4])
-    let totalRecordLength = 5 + recordLength
-    guard data.count >= totalRecordLength else {
-      return false
-    }
-
-    let recordPayload = Data(data[5 ..< totalRecordLength])
-    guard recordPayload.count >= 4,
-          recordPayload.first == 0x01
-    else {
-      return false
-    }
-
-    let clientHelloLength = Int(recordPayload[1]) << 16 | Int(recordPayload[2]) << 8
-      | Int(recordPayload[3])
-    guard recordPayload.count >= 4 + clientHelloLength else {
-      return false
-    }
-
-    let clientHelloData = Data(recordPayload[4 ..< (4 + clientHelloLength)])
-    return self.clientHelloContainsEncryptedClientHello(clientHelloData)
-  }
-
   public static func parse(_ data: Data) -> Result {
     switch self.parseHTTP(data) {
     case .some(let result):
@@ -248,46 +216,6 @@ public enum OutboundDataParser {
     }
 
     return .tlsNoServerName
-  }
-
-  private static func clientHelloContainsEncryptedClientHello(_ data: Data) -> Bool {
-    var reader = ByteReader(data)
-
-    guard reader.readUInt16() != nil,
-          reader.readBytes(count: 32) != nil,
-          let sessionIdLength = reader.readUInt8(),
-          reader.readBytes(count: Int(sessionIdLength)) != nil,
-          let cipherSuitesLength = reader.readUInt16(),
-          cipherSuitesLength.isMultiple(of: 2),
-          reader.readBytes(count: Int(cipherSuitesLength)) != nil,
-          let compressionMethodsLength = reader.readUInt8(),
-          reader.readBytes(count: Int(compressionMethodsLength)) != nil
-    else {
-      return false
-    }
-
-    guard reader.remainingCount > 0,
-          let extensionsLength = reader.readUInt16(),
-          let extensions = reader.readBytes(count: Int(extensionsLength))
-    else {
-      return false
-    }
-
-    var extensionReader = ByteReader(extensions)
-    while extensionReader.remainingCount > 0 {
-      guard let type = extensionReader.readUInt16(),
-            let length = extensionReader.readUInt16(),
-            extensionReader.readBytes(count: Int(length)) != nil
-      else {
-        return false
-      }
-
-      if type == 0xFE0D {
-        return true
-      }
-    }
-
-    return false
   }
 
   private static func httpHeaderNeedMoreBytes(_ data: Data) -> Int? {

--- a/swift/macapp/App/Sources/Filter/FilterProxy.swift
+++ b/swift/macapp/App/Sources/Filter/FilterProxy.swift
@@ -149,13 +149,6 @@ public class FilterProxy {
     )
     var filterFlow = FilterFlow(flow, userId: deferred.userId)
 
-    if !hasDeferredState {
-      self.store.log(event: .outboundDeferredStateMissing(
-        bundleId: filterFlow.bundleId,
-        readBytesStartOffset: readBytesStartOffset,
-      ))
-    }
-
     let mergedOutboundBytes = mergeOutboundBytes(
       existing: deferred.accumulatedReadBytes,
       readBytesStartOffset: readBytesStartOffset,
@@ -306,16 +299,6 @@ private extension FilterLogs.Event {
   static let outboundRetryCapacityExhausted = Self(id: "outboundRetryCapacityExhausted")
   static let outboundRetryStillInsufficient = Self(id: "outboundRetryStillInsufficient")
   static let outboundRetryClampedToMax = Self(id: "outboundRetryClampedToMax")
-
-  static func outboundDeferredStateMissing(
-    bundleId: String?,
-    readBytesStartOffset: Int,
-  ) -> Self {
-    Self(
-      id: "outboundDeferredStateMissing",
-      detail: "bundleId=\(bundleId ?? "nil") offset=\(readBytesStartOffset)",
-    )
-  }
 
   static func sawEncryptedClientHello_x100(
     bundleId: String?,

--- a/swift/macapp/App/Sources/Filter/FilterProxy.swift
+++ b/swift/macapp/App/Sources/Filter/FilterProxy.swift
@@ -17,7 +17,6 @@ public class FilterProxy {
 
   static let initialOutboundPeekBytes = 2048
   static let maxOutboundRetryBytes = 16384
-  static let encryptedClientHelloSampleRate = 100
 
   #if !DEBUG
     let store: FilterStore
@@ -27,7 +26,6 @@ public class FilterProxy {
 
   var deferredOutboundFlows: [UUID: DeferredOutboundFlow] = [:]
   var cancellables: Set<AnyCancellable> = []
-  var encryptedClientHelloSamplingCounter = 0
 
   // give the FilterDataProvider a simple boolean it can
   // quickly check to decide if it needs to pass the decision
@@ -159,21 +157,6 @@ public class FilterProxy {
     }
     let accumulatedReadBytes = mergedOutboundBytes.data
     let parseResult = filterFlow.parseOutboundData(accumulatedReadBytes)
-    switch parseResult {
-    case .tls, .tlsNoServerName:
-      self.encryptedClientHelloSamplingCounter += 1
-      if self.encryptedClientHelloSamplingCounter
-        .isMultiple(of: Self.encryptedClientHelloSampleRate),
-        OutboundDataParser.containsEncryptedClientHello(accumulatedReadBytes) {
-        let outerSNI: String? = if case .tls(let name) = parseResult { name } else { nil }
-        self.store.log(event: .sawEncryptedClientHello_x100(
-          bundleId: filterFlow.bundleId,
-          outerSNI: outerSNI,
-        ))
-      }
-    case .http, .needMoreBytes, .unsupportedProtocol, .malformed:
-      break
-    }
 
     if case .needMoreBytes(let requestedTotal) = parseResult,
        deferred.round == 0 {
@@ -299,16 +282,6 @@ private extension FilterLogs.Event {
   static let outboundRetryCapacityExhausted = Self(id: "outboundRetryCapacityExhausted")
   static let outboundRetryStillInsufficient = Self(id: "outboundRetryStillInsufficient")
   static let outboundRetryClampedToMax = Self(id: "outboundRetryClampedToMax")
-
-  static func sawEncryptedClientHello_x100(
-    bundleId: String?,
-    outerSNI: String?,
-  ) -> Self {
-    Self(
-      id: "sawEncryptedClientHello_x100",
-      detail: "bundleId=\(bundleId ?? "nil") outerSNI=\(outerSNI ?? "nil")",
-    )
-  }
 }
 
 public extension NEFilterFlow {

--- a/swift/macapp/App/Tests/AppTests/BlockedRequestsFeatureTests.swift
+++ b/swift/macapp/App/Tests/AppTests/BlockedRequestsFeatureTests.swift
@@ -128,6 +128,22 @@ final class BlockedRequestsFeatureTests: XCTestCase {
   }
 
   @MainActor
+  func testCloudflareEchBlockedRequestHiddenFromParent() async {
+    let (store, _) = AppReducer.testStore()
+
+    let ech = BlockedRequest(app: .mock, hostname: "cloudflare-ech.com")
+    await store.send(.xpc(.receivedExtensionMessage(.blockedRequest(ech))))
+
+    let echSub = BlockedRequest(app: .mock, hostname: "foo.cloudflare-ech.com")
+    await store.send(.xpc(.receivedExtensionMessage(.blockedRequest(echSub))))
+
+    let other = BlockedRequest(app: .mock, hostname: "example.com")
+    await store.send(.xpc(.receivedExtensionMessage(.blockedRequest(other)))) {
+      $0.blockedRequests.requests = [other]
+    }
+  }
+
+  @MainActor
   func testSimpleActions() async {
     let req = BlockedRequest.mock
     let (store, _) = AppReducer.testStore {

--- a/swift/macapp/App/Tests/FilterTests/FilterProxyTests.swift
+++ b/swift/macapp/App/Tests/FilterTests/FilterProxyTests.swift
@@ -231,30 +231,6 @@ final class FilterProxyTests: XCTestCase {
     expect(proxy.deferredOutboundFlows).toEqual([:])
   }
 
-  func testLogsMissingDeferredStateOnUnexpectedOutboundCallback() {
-    withDependencies {
-      $0.filterExtension.version = { "2.6.0" }
-    } operation: {
-      let proxy = FilterProxy(flowDecision: .block(.defaultNotAllowed))
-      let flow = NEFilterFlow.DTO.mock
-
-      let verdict = proxy.handleOutboundData(
-        from: flow,
-        readBytesStartOffset: 17,
-        readBytes: .init(),
-      )
-
-      expect(verdict.isDrop).toBeTrue()
-      expect(proxy.store.state.logs.events[.init(
-        id: "outboundDeferredStateMissing",
-        detail: "bundleId=com.acme.app offset=17",
-      )]).toEqual(1)
-      // gap log is suppressed when deferred state was missing, as the
-      // "gap" is trivially true for any non-zero start offset in that case
-      expect(proxy.store.state.logs.events[.init(id: "outboundBytesGapDetected")]).toBeNil()
-    }
-  }
-
   func testOutboundFlowStillNeedingMoreBytesAfterRetryFallsThroughToDecision() {
     withDependencies {
       $0.filterExtension.version = { "2.6.0" }
@@ -316,10 +292,6 @@ final class FilterProxyTests: XCTestCase {
       expect(proxy.deferredOutboundFlows[preservedId]?.round).toEqual(1)
       expect(proxy.deferredOutboundFlows[preservedId]?.accumulatedReadBytes).toEqual(preservedData)
       expect(proxy.deferredOutboundFlows[flow.identifier]).toBeNil()
-      expect(proxy.store.state.logs.events[.init(
-        id: "outboundDeferredStateMissing",
-        detail: "bundleId=com.acme.app offset=0",
-      )]).toEqual(1)
       expect(proxy.store.state.logs.events[.init(id: "outboundRetryCapacityExhausted")]).toEqual(1)
     }
   }

--- a/swift/macapp/App/Tests/FilterTests/FilterProxyTests.swift
+++ b/swift/macapp/App/Tests/FilterTests/FilterProxyTests.swift
@@ -342,68 +342,6 @@ final class FilterProxyTests: XCTestCase {
     }
   }
 
-  func testLogsEncryptedClientHelloSampledX100() {
-    withDependencies {
-      $0.filterExtension.version = { "2.6.0" }
-    } operation: {
-      let proxy = FilterProxy(flowDecision: .allow(.permittedByKey(.init())))
-      proxy.encryptedClientHelloSamplingCounter = FilterProxy.encryptedClientHelloSampleRate - 1
-      let flow = NEFilterFlow.DTO.mock
-      let data = makeTLSClientHello(
-        serverName: "www.google.com",
-        extraExtensions: [(type: 0xFE0D, payload: Data([0x01]))],
-      )
-      proxy.deferredOutboundFlows[flow.identifier] = .init(
-        userId: 501,
-        round: 1,
-        accumulatedReadBytes: .init(),
-      )
-
-      let verdict = proxy.handleOutboundData(
-        from: flow,
-        readBytesStartOffset: 0,
-        readBytes: data,
-      )
-
-      expect(verdict.isDrop).toBeFalse()
-      expect(proxy.store.state.logs.events[.init(
-        id: "sawEncryptedClientHello_x100",
-        detail: "bundleId=com.acme.app outerSNI=www.google.com",
-      )]).toEqual(1)
-    }
-  }
-
-  func testLogsEncryptedClientHelloSampledX100WithoutOuterSNI() {
-    withDependencies {
-      $0.filterExtension.version = { "2.6.0" }
-    } operation: {
-      let proxy = FilterProxy(flowDecision: .allow(.permittedByKey(.init())))
-      proxy.encryptedClientHelloSamplingCounter = FilterProxy.encryptedClientHelloSampleRate - 1
-      let flow = NEFilterFlow.DTO.mock
-      let data = makeTLSClientHello(
-        serverName: nil,
-        extraExtensions: [(type: 0xFE0D, payload: Data([0x01]))],
-      )
-      proxy.deferredOutboundFlows[flow.identifier] = .init(
-        userId: 501,
-        round: 1,
-        accumulatedReadBytes: .init(),
-      )
-
-      let verdict = proxy.handleOutboundData(
-        from: flow,
-        readBytesStartOffset: 0,
-        readBytes: data,
-      )
-
-      expect(verdict.isDrop).toBeFalse()
-      expect(proxy.store.state.logs.events[.init(
-        id: "sawEncryptedClientHello_x100",
-        detail: "bundleId=com.acme.app outerSNI=nil",
-      )]).toEqual(1)
-    }
-  }
-
   @MainActor
   func testBlockedDataFlowSendsDecisionIfSending() async {
     let sent = LockIsolated<[String]>([])
@@ -537,10 +475,7 @@ extension NEFilterNewFlowVerdict {
   }
 }
 
-private func makeTLSClientHello(
-  serverName: String?,
-  extraExtensions: [(type: UInt16, payload: Data)] = [],
-) -> Data {
+private func makeTLSClientHello(serverName: String?) -> Data {
   var clientHello = Data()
   clientHello.append(contentsOf: [0x03, 0x03])
   clientHello.append(Data(repeating: 0x11, count: 32))
@@ -563,11 +498,6 @@ private func makeTLSClientHello(
     extensions.append(uint16Bytes(0x0000))
     extensions.append(uint16Bytes(UInt16(serverNameExtension.count)))
     extensions.append(serverNameExtension)
-  }
-  for extraExtension in extraExtensions {
-    extensions.append(uint16Bytes(extraExtension.type))
-    extensions.append(uint16Bytes(UInt16(extraExtension.payload.count)))
-    extensions.append(extraExtension.payload)
   }
 
   clientHello.append(uint16Bytes(UInt16(extensions.count)))

--- a/swift/macapp/Xcode/Gertrude/Info.plist
+++ b/swift/macapp/Xcode/Gertrude/Info.plist
@@ -21,9 +21,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.9.1</string>
+    <string>2.9.2</string>
     <key>CFBundleVersion</key>
-    <string>2.9.1</string>
+    <string>2.9.2</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>

--- a/swift/macapp/Xcode/GertrudeFilterExtension/Info.plist
+++ b/swift/macapp/Xcode/GertrudeFilterExtension/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.9.1</string>
+    <string>2.9.2</string>
     <key>CFBundleVersion</key>
-    <string>2.9.1</string>
+    <string>2.9.2</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>NSHumanReadableCopyright</key>

--- a/swift/macapp/readme.md
+++ b/swift/macapp/readme.md
@@ -2,8 +2,9 @@
 
 ## Release notes
 
-- `(next)` (in dev)
-  - refine filter logging for sni gap, ech sample
+- `2.9.2` (stable 4/23/26)
+  - don't show cloudflare ech domain in blocked reqs window
+  - reduce filter logging noise for ech/outbound-gaps
 - `2.9.1` (stable 4/21/26)
   - always-blocked items, enforced even during filter suspensions
   - real sni parsing for better non-safari support


### PR DESCRIPTION
```sql
 SELECT event_id, COUNT(*) FROM system.interesting_events
  WHERE context = 'macapp-filter'
    AND event_id IN ('outboundDeferredStateMissing','outboundBytesGapDetected','sawEncryptedClientHello_x100')
  GROUP BY event_id ORDER BY event_id;

  DELETE FROM system.interesting_events
  WHERE context = 'macapp-filter'
    AND event_id IN ('outboundDeferredStateMissing','outboundBytesGapDetected','sawEncryptedClientHello_x100');

BEGIN;

  DELETE FROM parent.keys
  WHERE id IN (
    '8269b502-db0d-4ddc-a190-775d21df0f7c',
    'd37e66f4-3ca8-437a-90c8-9f9f151f50c8',
    '7d538969-a0c2-49d8-b2b6-0efdd48e5844',
    '145e0906-c0e3-4250-9ef8-67be7698e1f1',
    '7100a867-e6ca-44da-8bc5-63632b124ccf',
    '2f4b130d-ff42-40b5-a115-1c9c681d4219',
    '44a0d220-1a81-4632-921e-c1d94912b034',
    '69913d58-dc96-4ba0-9e2c-d34a48ec5537',
    'cb251e3c-bc4f-47ba-86c2-8c9ea5def816',
    'e916218e-3133-4bf3-8033-1299936e3682',
    'a5669af3-1349-4e17-9cf6-509e291d58b4',
    'd73ba343-2d43-4cba-a38b-930ae96c32d3',
    '9402a1ba-73c5-41d9-83da-8752c76d1191',
    '32657a1e-44f4-41d8-a42b-6b938c694b7d'
  );

  -- verify rowcount = 14 before committing
  COMMIT;

  Query-based variant:

  BEGIN;

  DELETE FROM parent.keys
  WHERE key->>'domain' = 'cloudflare-ech.com';

  -- inspect rowcount, then:
  COMMIT;

```