### PR TITLE
add iPad16,11 to ModelIdentifier mapping

### DIFF
--- a/swift/api/Sources/Api/Lib/ModelIdentifier.swift
+++ b/swift/api/Sources/Api/Lib/ModelIdentifier.swift
@@ -153,6 +153,8 @@ enum ModelIdentifier {
     // iPad Air M4 (2026)
     "iPad16,7": "iPad Air 11-inch (M4)",
     "iPad16,8": "iPad Air 11-inch (M4)",
+    "iPad16,10": "iPad Air 13-inch (M4)",
+    "iPad16,11": "iPad Air 13-inch (M4)",
 
     // iPad Air M3 (2025)
     "iPad15,3": "iPad Air 11-inch (M3)",


### PR DESCRIPTION
Adds `iPad16,10` + `iPad16,11` (wifi/cellular pair) as `iPad Air 13-inch (M4)` to the `ModelIdentifier.mapping` table. `#info` slack has been getting repeated alerts for this unknown identifier. Per [DeviceKit](https://github.com/devicekit/DeviceKit/blob/master/Source/Device.generated.swift) (`case "iPad16,10", "iPad16,11": return iPadAir13M4`), both identifiers are the 13-inch iPad Air M4.