### PR TITLE
show music-only ios devices connected

### DIFF
--- a/swift/api/Sources/Api/PairQL/Dashboard/Pairs/DashboardWidgets_v2.swift
+++ b/swift/api/Sources/Api/PairQL/Dashboard/Pairs/DashboardWidgets_v2.swift
@@ -129,6 +129,10 @@ extension DashboardWidgets_v2: NoInputResolver {
       among: iosDevices.map(\.id),
       in: context.db,
     )
+    async let musicConnectedDeviceIdsAsync = MusicApp.Token.connectedDeviceIds(
+      among: iosDevices.map(\.id),
+      in: context.db,
+    )
     async let unlockRequests = Api.UnlockRequest.query()
       .where(.computerUserId |=| computerUsers.map(\.id))
       .where(.status == .enum(RequestStatus.pending))
@@ -161,6 +165,7 @@ extension DashboardWidgets_v2: NoInputResolver {
       .reduce(into: [:]) { map, s in map[s.deviceId] = s }
     let connectedDeviceIds = try await blockerConnectedDeviceIdsAsync
       .union(amConnectedDeviceIdsAsync)
+      .union(musicConnectedDeviceIdsAsync)
 
     return try await .init(
       children: children.concurrentMap { child in

--- a/web/dash/components/src/Dashboard/ChildDeviceCard.tsx
+++ b/web/dash/components/src/Dashboard/ChildDeviceCard.tsx
@@ -59,7 +59,7 @@ function iosStatusInfo(status: `setupComplete` | `pendingSetup`): {
 } {
   switch (status) {
     case `setupComplete`:
-      return { pillClasses: `bg-green-50 text-green-700`, text: `Protected` };
+      return { pillClasses: `bg-green-200/50 text-green-700`, text: `Connected` };
     case `pendingSetup`:
       return { pillClasses: `bg-amber-50 text-amber-700`, text: `Pending setup` };
   }


### PR DESCRIPTION
The `ChildDeviceCard` was showing "Pending setup" when a child was connected to a Gertrude Music client, but not to Blocker or AM, even though that might be a totally state.

before:
<img width="558" height="292" alt="Screenshot 2026-06-21 at 7 36 31 PM" src="https://github.com/user-attachments/assets/679304fb-f87d-4ba0-8970-a5795c39b296" />

after:
<img width="553" height="280" alt="Screenshot 2026-06-21 at 7 36 50 PM" src="https://github.com/user-attachments/assets/c99ca835-1b2c-41f9-8db0-589b5ee7da09" />