### PR TITLE
api: fix claim music after blocker bug

### DIFF
--- a/swift/api/Sources/Api/PairQL/Dashboard/ClaimDevice.swift
+++ b/swift/api/Sources/Api/PairQL/Dashboard/ClaimDevice.swift
@@ -9,7 +9,7 @@ func claimDevice<Output>(
   baseId: String,
   in context: ParentContext,
   onResume: (IOSDevice, Child) async throws -> Output,
-  beforeFreshClaim: ((IOSDevice) async throws -> Void)? = nil,
+  beforeClaim: ((IOSDevice) async throws -> Void)? = nil,
   onFresh: (IOSDevice, Child) async throws -> Output,
 ) async throws -> Output {
   let found = try? await IOSDevice.query()
@@ -24,6 +24,12 @@ func claimDevice<Output>(
 
   if let childId = device.childId {
     if let child = try? await context.verifiedChild(from: childId) {
+      if device.claimedAt == nil {
+        if let beforeClaim {
+          try await beforeClaim(device)
+        }
+        try await device.claim(for: child, in: context.db)
+      }
       return try await onResume(device, child)
     } else {
       let ownerChild = try? await Child.query()
@@ -50,8 +56,8 @@ func claimDevice<Output>(
     throw context.error("\(baseId)-3", .badRequest, user: msg)
   }
 
-  if let beforeFreshClaim {
-    try await beforeFreshClaim(device)
+  if let beforeClaim {
+    try await beforeClaim(device)
   }
 
   let child = switch childAssignment {

--- a/swift/api/Sources/Api/PairQL/Dashboard/Pairs/ClaimMusicDevice.swift
+++ b/swift/api/Sources/Api/PairQL/Dashboard/Pairs/ClaimMusicDevice.swift
@@ -28,7 +28,7 @@ extension ClaimMusicDevice: Resolver {
       onResume: { device, child in
         try await self.output(device: device, child: child, code: input.code, in: context)
       },
-      beforeFreshClaim: { device in
+      beforeClaim: { device in
         try await self.requireMusicInstall(for: device, eventId: "11369678", in: context)
         let account = try await context.currentBillingAccount()
         try requireGertrudeMusicAccess(in: context, billing: account)

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/ClaimMusicDeviceResolverTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/ClaimMusicDeviceResolverTests.swift
@@ -25,7 +25,7 @@ final class ClaimMusicDeviceResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testFreshClaimNewChildSetsDeviceFields() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
     let code = Int.random(in: 100_000 ... 999_999)
     let device = try await self.unclaimedMusicDevice(code: code)
 
@@ -51,7 +51,7 @@ final class ClaimMusicDeviceResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testFreshClaimExistingChildSetsDeviceFields() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let code = Int.random(in: 100_000 ... 999_999)
     let device = try await self.unclaimedMusicDevice(code: code)
@@ -70,7 +70,7 @@ final class ClaimMusicDeviceResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testResumeClaimBySameParentReturnsOutput() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let code = Int.random(in: 100_000 ... 999_999)
     let device = try await self.db.create(IOSDevice.random {
@@ -180,17 +180,6 @@ final class ClaimMusicDeviceResolverTests: ApiTestCase, @unchecked Sendable {
 }
 
 extension ClaimMusicDeviceResolverTests {
-  private func grantMusicAccess(to parentId: Parent.Id) async throws {
-    try await self.db.create(BillingIdentity(parentId: parentId))
-    try await self.db.create(StripeSubscription(
-      parentId: parentId,
-      tier: .light,
-      stripeId: .init("sub_\(parentId.rawValue.uuidString.prefix(8))"),
-      stripeStatus: .active,
-      currentPeriodEnd: .reference + .days(30),
-    ))
-  }
-
   @discardableResult
   private func unclaimedMusicDevice(code: Int) async throws -> IOSDevice {
     let device = try await self.db.create(IOSDevice.random {

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/CrossAppClaimTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/CrossAppClaimTests.swift
@@ -1,11 +1,67 @@
 import Dependencies
 import DuetSQL
+import PairQL
 import XCTest
 import XExpect
 
 @testable import Api
 
 final class CrossAppClaimTests: ApiTestCase, @unchecked Sendable {
+  func testMusicClaimAfterBlockerConnectSetsClaimedAt() async throws {
+    let parent = try await self.parent()
+    let child = try await self.db.create(Child.random { $0.parentId = parent.id })
+    try await self.addLightPaidSubscription(for: parent.id)
+    let code = Int.random(in: 100_000 ... 999_999)
+    var device = try await self.db.create(IOSDevice.random {
+      $0.claimCode = code
+      $0.claimCodeExpiresAt = .reference + .days(7)
+    })
+    try await self.db.create(MusicApp.Install(deviceId: device.id, appVersion: "1.0.0"))
+    try await device.bindChild(child, in: self.db)
+
+    let bound = try await self.db.find(device.id)
+    expect(bound.claimedAt).toBeNil()
+
+    _ = try await ClaimMusicDevice.resolve(
+      with: .init(code: code, child: .newChild(name: "Ignored")),
+      in: parent.context,
+    )
+
+    let claimed = try await self.db.find(device.id)
+    expect(claimed.childId).toEqual(child.id)
+    expect(claimed.claimedAt).not.toBeNil()
+
+    let children = try await Child.query()
+      .where(.parentId == parent.id)
+      .all(in: self.db)
+    expect(children).toHaveCount(1)
+  }
+
+  func testMusicClaimAfterBlockerConnectWithoutAccessDoesNotSetClaimedAt() async throws {
+    let parent = try await self.parent()
+    let child = try await self.db.create(Child.random { $0.parentId = parent.id })
+    let code = Int.random(in: 100_000 ... 999_999)
+    var device = try await self.db.create(IOSDevice.random {
+      $0.claimCode = code
+      $0.claimCodeExpiresAt = .reference + .days(7)
+    })
+    try await self.db.create(MusicApp.Install(deviceId: device.id, appVersion: "1.0.0"))
+    try await device.bindChild(child, in: self.db)
+
+    do {
+      _ = try await ClaimMusicDevice.resolve(
+        with: .init(code: code, child: .newChild(name: "Ignored")),
+        in: parent.context,
+      )
+      XCTFail("expected payment required")
+    } catch let error as PqlError {
+      expect(error.type).toEqual(.paymentRequired)
+    }
+
+    let updated = try await self.db.find(device.id)
+    expect(updated.claimedAt).toBeNil()
+  }
+
   func testCodeReuse_amClaimFirst_blockerFunnelResumesAndHealsBlockGroups() async throws {
     let parent = try await self.parent()
     let code = Int.random(in: 100_000 ... 999_999)

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/GetMusicClaimDataResolverTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/GetMusicClaimDataResolverTests.swift
@@ -24,7 +24,7 @@ final class GetMusicClaimDataResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testResumeClaimedBySameParentReturnsDone() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let code = Int.random(in: 100_000 ... 999_999)
     let device = try await self.db.create(IOSDevice.random {
@@ -45,7 +45,7 @@ final class GetMusicClaimDataResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testResumeClaimedBySameParentWithoutMusicInstallThrowsNotFound() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let code = Int.random(in: 100_000 ... 999_999)
     _ = try await self.db.create(IOSDevice.random {
@@ -61,7 +61,7 @@ final class GetMusicClaimDataResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testUnclaimedValidCodeReturnsChildrenAndNoResumeStep() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let code = Int.random(in: 100_000 ... 999_999)
     let device = try await self.db.create(IOSDevice.random {
@@ -146,18 +146,5 @@ final class GetMusicClaimDataResolverTests: ApiTestCase, @unchecked Sendable {
     try await expectErrorFrom {
       try await GetMusicClaimData.resolve(with: .init(code: code), in: parent.context)
     }.toContain("not found")
-  }
-}
-
-extension GetMusicClaimDataResolverTests {
-  private func grantMusicAccess(to parentId: Parent.Id) async throws {
-    try await self.db.create(BillingIdentity(parentId: parentId))
-    try await self.db.create(StripeSubscription(
-      parentId: parentId,
-      tier: .light,
-      stripeId: .init("sub_\(parentId.rawValue.uuidString.prefix(8))"),
-      stripeStatus: .active,
-      currentPeriodEnd: .reference + .days(30),
-    ))
   }
 }

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/MusicAlbumResolverTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/MusicAlbumResolverTests.swift
@@ -171,7 +171,7 @@ final class MusicAlbumResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testRejectsMusicManagementWithoutConnectedMusic() async throws {
     let child = try await self.child()
-    try await self.grantMusicAccess(to: child.parent.model.id)
+    try await self.addLightPaidSubscription(for: child.parent.model.id)
 
     do {
       _ = try await ApproveMusicAlbum.resolve(
@@ -196,7 +196,7 @@ final class MusicAlbumResolverTests: ApiTestCase, @unchecked Sendable {
   }
 
   private func connectMusicApp(for child: ChildEntities) async throws {
-    try await self.grantMusicAccess(to: child.parent.model.id)
+    try await self.addLightPaidSubscription(for: child.parent.model.id)
     let device = try await self.db.create(IOSDevice.random {
       $0.childId = child.id
       $0.claimedAt = .reference
@@ -205,17 +205,6 @@ final class MusicAlbumResolverTests: ApiTestCase, @unchecked Sendable {
       MusicApp.Install(deviceId: device.id, appVersion: "1.0.0"),
     )
     try await self.db.create(MusicApp.Token(installId: install.id))
-  }
-
-  private func grantMusicAccess(to parentId: Parent.Id) async throws {
-    try await self.db.create(BillingIdentity(parentId: parentId))
-    try await self.db.create(StripeSubscription(
-      parentId: parentId,
-      tier: .light,
-      stripeId: .init("sub_\(parentId.rawValue.uuidString.prefix(8))"),
-      stripeStatus: .active,
-      currentPeriodEnd: .reference + .days(30),
-    ))
   }
 
   private func input(

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/SearchMusicCatalogResolverTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/SearchMusicCatalogResolverTests.swift
@@ -8,7 +8,7 @@ import XExpect
 final class SearchMusicCatalogResolverTests: ApiTestCase, @unchecked Sendable {
   func testSearchesAppleMusicAlbums() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
 
     let output = try await withDependencies {
       $0.appleMusic.searchAlbums = { search in
@@ -46,7 +46,7 @@ final class SearchMusicCatalogResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testClampsSearchLimit() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
 
     let highLimit = try await withDependencies {
       $0.appleMusic.searchAlbums = { search in
@@ -86,7 +86,7 @@ final class SearchMusicCatalogResolverTests: ApiTestCase, @unchecked Sendable {
 
   func testBlankQueryReturnsNoAlbumsWithoutSearching() async throws {
     let parent = try await self.parent()
-    try await self.grantMusicAccess(to: parent.id)
+    try await self.addLightPaidSubscription(for: parent.id)
 
     let output = try await withDependencies {
       $0.appleMusic
@@ -113,17 +113,6 @@ final class SearchMusicCatalogResolverTests: ApiTestCase, @unchecked Sendable {
     } catch let error as PqlError {
       expect(error.type).toEqual(.paymentRequired)
     }
-  }
-
-  private func grantMusicAccess(to parentId: Parent.Id) async throws {
-    try await self.db.create(BillingIdentity(parentId: parentId))
-    try await self.db.create(StripeSubscription(
-      parentId: parentId,
-      tier: .light,
-      stripeId: .init("sub_\(parentId.rawValue.uuidString.prefix(8))"),
-      stripeStatus: .active,
-      currentPeriodEnd: .reference + .days(30),
-    ))
   }
 }
 

--- a/swift/api/Tests/ApiTests/Entities.swift
+++ b/swift/api/Tests/ApiTests/Entities.swift
@@ -141,6 +141,17 @@ struct ParentWithOnboardedChildEntities {
 }
 
 extension ApiTestCase {
+  func addLightPaidSubscription(for parentId: Parent.Id) async throws {
+    try await self.db.create(BillingIdentity(parentId: parentId))
+    try await self.db.create(StripeSubscription(
+      parentId: parentId,
+      tier: .light,
+      stripeId: .init("sub_\(parentId.rawValue.uuidString.prefix(8))"),
+      stripeStatus: .active,
+      currentPeriodEnd: .reference + .days(30),
+    ))
+  }
+
   func parent(
     with config: (inout Parent) -> Void = { _ in },
   ) async throws -> ParentEntities {

--- a/swift/api/Tests/ApiTests/MusicPairResolvers/GetApprovedMusicLibraryResolverTests.swift
+++ b/swift/api/Tests/ApiTests/MusicPairResolvers/GetApprovedMusicLibraryResolverTests.swift
@@ -27,7 +27,7 @@ final class GetApprovedMusicLibraryResolverTests: ApiTestCase, @unchecked Sendab
 
   func testReturnsApprovedAlbumsForAuthedChild() async throws {
     let child = try await self.child()
-    try await self.grantMusicAccess(to: child.parent.model.id)
+    try await self.addLightPaidSubscription(for: child.parent.model.id)
     let (device, install) = try await self.claimedInstall(for: child)
     let ctx = MusicApp.InstallContext(
       requestId: "mock-req-id",
@@ -106,7 +106,7 @@ final class GetApprovedMusicLibraryResolverTests: ApiTestCase, @unchecked Sendab
 
   func testAuthedRouteResolvesTokenAndReturnsApprovedLibrary() async throws {
     let child = try await self.child()
-    try await self.grantMusicAccess(to: child.parent.model.id)
+    try await self.addLightPaidSubscription(for: child.parent.model.id)
     let (_, install) = try await self.claimedInstall(for: child)
     let token = try await self.db.create(MusicApp.Token(installId: install.id))
     try await self.db.create(Music.ApprovedAlbum(
@@ -179,17 +179,6 @@ final class GetApprovedMusicLibraryResolverTests: ApiTestCase, @unchecked Sendab
     } catch let error as PqlError {
       expect(error.type).toEqual(.unauthorized)
     }
-  }
-
-  private func grantMusicAccess(to parentId: Parent.Id) async throws {
-    try await self.db.create(BillingIdentity(parentId: parentId))
-    try await self.db.create(StripeSubscription(
-      parentId: parentId,
-      tier: .light,
-      stripeId: .init("sub_\(parentId.rawValue.uuidString.prefix(8))"),
-      stripeStatus: .active,
-      currentPeriodEnd: .reference + .days(30),
-    ))
   }
 
   private func claimedInstall(for child: ChildEntities) async throws


### PR DESCRIPTION
this fixes a bug i ran into last night trying to claim Gertrude Music for harriet's phone, the claim didn't work because she already had a blocker app claim/install. the dashboard made it look like it worked, but it failed.

incidentally, a review agent pointed out that we had 5 exact copies of `func grantMusicAccess(...)` and my codex agent had added a **sixth!!** this is something i want to think about how we might mitigate, these agents often copy paste stuff, and if we don't catch it, we just keep adding redundant code. keep your eye out for stuff like this, and we should consider skills and review techniques to mitigate this.