### PR TITLE
api: fix admin ios-events deep link after blocker route rename

### DIFF
--- a/swift/api/Sources/Api/Services/AdminLink.swift
+++ b/swift/api/Sources/Api/Services/AdminLink.swift
@@ -12,7 +12,7 @@ struct AdminLink {
       case .parent(let id):
         "parents/\(id.lowercased)"
       case .iosDeviceEvents(let vendorId):
-        "ios/\(vendorId.lowercased)/events"
+        "blocker/\(vendorId.lowercased)/events"
       case .verify(let token):
         "verify/\(token.uuidString.lowercased())"
       }


### PR DESCRIPTION
PR #784 renamed the admin route `/ios/:vendorId/events` → `/blocker/:vendorId/events`. `AdminLink.iosDeviceEvents` still emitted the old `ios/...` path, so the "see events" links in the iOS-onboarding Slack pings (LogIOSEvent_v2) 404'd.

Audit confirmed `.iosDeviceEvents` was the only broken deep link (`.parent`/`.verify` routes unchanged). Added a regression test.