### PR TITLE
api,dash: disambiguate suspend filter request computer source

### DIFF
--- a/swift/api/Sources/Api/PairQL/Dashboard/Pairs/GetSuspendFilterRequest.swift
+++ b/swift/api/Sources/Api/PairQL/Dashboard/Pairs/GetSuspendFilterRequest.swift
@@ -1,3 +1,4 @@
+import DuetSQL
 import Foundation
 import Gertie
 import PairQL
@@ -11,6 +12,7 @@ struct GetSuspendFilterRequest: Pair {
     var deviceId: Api.ComputerUser.Id
     var status: RequestStatus
     var userName: String
+    var deviceName: String?
     var requestedDurationInSeconds: Int
     var requestComment: String?
     var responseComment: String?
@@ -30,11 +32,12 @@ extension GetSuspendFilterRequest: Resolver {
     if Semver(userDevice.appVersion)! >= .init("2.1.0")! {
       extraMonitoringOptions = user.extraMonitoringOptions.mapKeys(\.magicString)
     }
-    return Output(
+    return try await Output(
       id: id,
       deviceId: userDevice.id,
       status: request.status,
       userName: user.name,
+      deviceName: disambiguatingDeviceName(for: userDevice, in: context),
       requestedDurationInSeconds: request.duration.rawValue,
       requestComment: request.requestComment,
       responseComment: request.responseComment,
@@ -42,4 +45,16 @@ extension GetSuspendFilterRequest: Resolver {
       createdAt: request.createdAt,
     )
   }
+}
+
+private func disambiguatingDeviceName(
+  for userDevice: ComputerUser,
+  in context: ParentContext,
+) async throws -> String? {
+  let childComputerUsers = try await ComputerUser.query()
+    .where(.childId == userDevice.childId)
+    .all(in: context.db)
+  guard Set(childComputerUsers.map(\.computerId)).count > 1 else { return nil }
+  let computer = try await userDevice.computer(in: context.db)
+  return computer.customName ?? computer.model.shortDescription
 }

--- a/swift/api/Tests/ApiTests/DashboardPairResolvers/AuthedParentResolverTests.swift
+++ b/swift/api/Tests/ApiTests/DashboardPairResolvers/AuthedParentResolverTests.swift
@@ -581,6 +581,45 @@ final class AuthedParentResolverTests: ApiTestCase, @unchecked Sendable {
     expect(output.userName).toEqual(child.name)
     expect(output.requestedDurationInSeconds).toEqual(request.duration.rawValue)
     expect(output.status).toEqual(request.status)
+    expect(output.deviceName).toBeNil() // child on a single computer -> no disambiguation
+  }
+
+  func testGetSuspendFilterRequestPrefersCustomDeviceNameWhenChildOnMultipleComputers(
+  ) async throws {
+    let child = try await self.child()
+    let requesting = try await child.withDevice(computer: { $0.customName = "Joey's MacBook" })
+    _ = try await child.withDevice() // second computer makes the request ambiguous
+
+    var request = MacApp.SuspendFilterRequest.random
+    request.computerUserId = requesting.computerUser.id
+    try await self.db.create(request)
+
+    let output = try await GetSuspendFilterRequest.resolve(
+      with: request.id,
+      in: context(child.parent),
+    )
+
+    expect(output.deviceName).toEqual("Joey's MacBook")
+  }
+
+  func testGetSuspendFilterRequestFallsBackToModelNameWhenNoCustomName() async throws {
+    let child = try await self.child()
+    let requesting = try await child.withDevice(computer: {
+      $0.customName = nil
+      $0.modelIdentifier = "Mac16,10"
+    })
+    _ = try await child.withDevice() // second computer makes the request ambiguous
+
+    var request = MacApp.SuspendFilterRequest.random
+    request.computerUserId = requesting.computerUser.id
+    try await self.db.create(request)
+
+    let output = try await GetSuspendFilterRequest.resolve(
+      with: request.id,
+      in: context(child.parent),
+    )
+
+    expect(output.deviceName).toEqual(requesting.computer.model.shortDescription)
   }
 
   func testGetUnlockRequests() async throws {

--- a/web/dash/app/cypress/e2e/suspend-filter.cy.ts
+++ b/web/dash/app/cypress/e2e/suspend-filter.cy.ts
@@ -72,4 +72,14 @@ describe(`suspend filter request flow`, () => {
     cy.testId(`select-suspension-duration`).contains(`custom duration`);
     cy.contains(`Custom duration (minutes):`);
   });
+
+  it(`shows the originating device when the request is device-ambiguous`, () => {
+    cy.interceptPql(
+      `GetSuspendFilterRequest`,
+      mock.suspendFilterRequest({ id: `1`, deviceName: `Mac mini` }),
+    );
+    cy.visit(`children/user-1/suspend-filter-requests/1`);
+    cy.contains(`on`);
+    cy.contains(`Mac mini`);
+  });
 });

--- a/web/dash/app/src/components/routes/SuspendFilter.tsx
+++ b/web/dash/app/src/components/routes/SuspendFilter.tsx
@@ -111,6 +111,7 @@ const SuspendFilter: React.FC = () => {
     >
       <SuspendFilterRequestForm
         username={request.userName}
+        deviceName={request.deviceName}
         requestedDurationInSeconds={request.requestedDurationInSeconds}
         requestComment={request.requestComment}
         durationInSeconds={state.grantedDurationInSeconds}

--- a/web/dash/components/src/Users/SuspendFilterRequestForm.tsx
+++ b/web/dash/components/src/Users/SuspendFilterRequestForm.tsx
@@ -6,6 +6,7 @@ import UserInputText from '../UserInputText';
 
 type Props = {
   username: string;
+  deviceName?: string;
   requestComment?: string;
   requestedDurationInSeconds: number;
   durationInSeconds: string;
@@ -22,6 +23,7 @@ type Props = {
 
 const SuspendFilterRequestForm: React.FC<Props> = ({
   username,
+  deviceName,
   requestedDurationInSeconds,
   requestComment,
   durationInSeconds,
@@ -53,6 +55,11 @@ const SuspendFilterRequestForm: React.FC<Props> = ({
       <UserInputText small>{Math.floor(requestedDurationInSeconds / 60)}</UserInputText>
       {` `}
       minutes
+      {deviceName && (
+        <>
+          {` `}on <UserInputText small>{deviceName}</UserInputText>
+        </>
+      )}
       {requestComment ? `, with the comment:` : `.`}
     </div>
     {requestComment && (

--- a/web/shared/pairql/src/dashboard/shared.ts
+++ b/web/shared/pairql/src/dashboard/shared.ts
@@ -253,6 +253,7 @@ export interface SuspendFilterRequest {
   deviceId: UUID;
   status: RequestStatus;
   userName: string;
+  deviceName?: string;
   requestedDurationInSeconds: number;
   requestComment?: string;
   responseComment?: string;

--- a/web/storybook/stories/dash/Children/SuspendFilterRequestForm.stories.tsx
+++ b/web/storybook/stories/dash/Children/SuspendFilterRequestForm.stories.tsx
@@ -64,4 +64,10 @@ export const CustomDuration: Story = props({
   customDurationInMinutes: `77`,
 });
 
+// @screenshot: xs,md
+export const WithDeviceName: Story = props({
+  ...Default.args,
+  deviceName: `Mac mini`,
+});
+
 export default meta;


### PR DESCRIPTION
from a feature request that came in this morning from a long time user:

> It would be really helpful if the Gertrude request included which device the filter will be suspended on. We have Gertrude installed on a Mac mini as well as a laptop and the laptop is more restricted in what we allow - for obvious reasons.

this PR adds a `on [computer name]` - but only when there is real ambiguity, which from the DB, is in about 13% of the cases.

<img width="616" height="831" alt="Screenshot 2026-06-29 at 3 32 17 PM" src="https://github.com/user-attachments/assets/0d9ae8de-25b4-4118-8bc7-767473c4cd1a" />
