### PR TITLE
made logo not touch hero text on small screens

### DIFF
--- a/web/site/components/ToolsForSafetyBlock.tsx
+++ b/web/site/components/ToolsForSafetyBlock.tsx
@@ -58,7 +58,7 @@ const ToolsForSafetyBlock: React.FC = () => {
   const scrollProgress = Math.min(scrollY / 600, 1);
 
   return (
-    <section className="min-h-screen bg-gradient-to-br from-white via-white via-55% to-fuchsia-200 px-4 xs:px-6 sm:px-8 md:px-20 pt-4 xs:pt-16 sm:pt-20 md:pt-24 pb-12 xs:pb-16 sm:pb-20 md:pb-24 flex flex-col items-center justify-center relative overflow-hidden">
+    <section className="min-h-screen bg-gradient-to-br from-white via-white via-55% to-fuchsia-200 px-4 xs:px-6 sm:px-8 md:px-20 pt-24 xs:pt-28 sm:pt-24 md:pt-28 pb-12 xs:pb-16 sm:pb-20 md:pb-24 flex flex-col items-center justify-start sm:justify-center relative overflow-x-hidden md:overflow-hidden">
       <div
         className="absolute inset-0 bg-gradient-to-b from-white to-fuchsia-600 pointer-events-none"
         style={{ opacity: scrollProgress * 0.7 }}


### PR DESCRIPTION
before:
<img width="400" height="691" alt="Screenshot 2026-06-30 at 12 31 08 PM" src="https://github.com/user-attachments/assets/2486f4cd-35f4-4855-a9f5-e5f97f53fb99" />

after:
<img width="407" height="691" alt="Screenshot 2026-06-30 at 12 31 33 PM" src="https://github.com/user-attachments/assets/f65bed57-c344-4779-bc0b-3d6135688590" />
