### PR TITLE
blocker,api: surface supervision payment gates in app

### DIFF
--- a/swift/api/Sources/Api/PairQL/Admin/Pairs/IOSDeviceEvents.swift
+++ b/swift/api/Sources/Api/PairQL/Admin/Pairs/IOSDeviceEvents.swift
@@ -225,8 +225,10 @@ extension IOSDeviceEvents: Resolver {
     case "ad87c533": #"Code Not Claimed → "Continue""#
     case "b496da4b": #"Code Expired → "Get a new code""#
     case "560908e7": #"Code Expired → "Start over""#
-    case "f2729c3c": #"Claimed Not Supervised → "Retry supervision""#
+    case "6dd407cb": #"Claimed Not Supervised → "Check again" (re-polls)"#
+    case "f2729c3c": #"Claimed Not Supervised → "Retry supervision" (deprecated, re-walked instructions)"#
     case "36d7be7c": #"Claimed Not Supervised → "Retry" (deprecated, self-report)"#
+    case "b5e8076e": #"Requires Subscription → "Try Again" (re-polls)"#
     case "d664b520": #"Retry Supervision → "Continue""#
     case "00b0c478": "⚠ Unreachable: missing supervision code"
     case "4693f615": #"Profile Removed Recovery → "Install""#
@@ -248,6 +250,7 @@ extension IOSDeviceEvents: Resolver {
     // --- Supervision Boot-Up Detection ---
     case "e9b86e6b": "Supervision reboot: code not claimed"
     case "80580cd5": "Supervision reboot: claimed not supervised"
+    case "a7d41f0e": "Supervision reboot: requires subscription"
     case "0b15e23f": "Supervision reboot: code expired/not found"
     case "05a47c3a": "Supervision reboot: needs profile"
     case "94991de7": "⚠ Supervision reboot: state disagreement"

--- a/swift/api/Sources/Api/PairQL/iOS/Resolvers/CheckSupervisionFlowStatus.swift
+++ b/swift/api/Sources/Api/PairQL/iOS/Resolvers/CheckSupervisionFlowStatus.swift
@@ -49,6 +49,19 @@ extension CheckSupervisionFlowStatus: Resolver {
       supervised: .byGertrude(claimCode: input.code),
     )
 
+    if supervision.supervisedAt == nil || supervision.profileInstalledAt == nil {
+      let parent = try await child.parent(in: ctx.db)
+      let billing = try await parent.billingAccountSnapshot(
+        in: ctx.db,
+        at: get(dependency: \.date.now),
+      )
+      let clientSupportsRequiresSubscription = input.appVersion != nil
+      if clientSupportsRequiresSubscription,
+         billing.paymentActionForMissingLightPlanCapability(.superviseIosDevice) != nil {
+        return .requiresSubscription(data)
+      }
+    }
+
     if supervision.supervisedAt == nil {
       return .claimed(data)
     }

--- a/swift/api/Tests/ApiTests/iOSPairResolvers/CheckSupervisionFlowStatusResolverTests.swift
+++ b/swift/api/Tests/ApiTests/iOSPairResolvers/CheckSupervisionFlowStatusResolverTests.swift
@@ -79,6 +79,7 @@ final class CheckSupervisionFlowStatusResolverTests: ApiTestCase, @unchecked Sen
 
   func testClaimed_notYetSupervised() async throws {
     let parent = try await self.parent()
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let uuids = MockUUIDs()
     let device = try await self.db.create(IOSDevice(
@@ -115,8 +116,87 @@ final class CheckSupervisionFlowStatusResolverTests: ApiTestCase, @unchecked Sen
     )))
   }
 
+  func testRequiresSubscription_claimedButUnpaid() async throws {
+    let parent = try await self.parent() // no paid subscription
+    let child = try await self.db.create(Child.random { $0.parentId = parent.id })
+    let uuids = MockUUIDs()
+    let device = try await self.db.create(IOSDevice(
+      id: .init(),
+      childId: child.id,
+      modelIdentifier: "iPhone15,2",
+      iosVersion: "18.2",
+    ))
+    let claim = try await self.createClaim(
+      .blockerSupervise,
+      device.id,
+      child.id,
+      claimedAt: .reference,
+    )
+    try await self.db.create(BlockerApp.Install.mock { $0.deviceId = device.id })
+    try await self.db.create(BlockerApp.Supervision(deviceId: device.id))
+
+    let output = try await withDependencies {
+      $0.date = .constant(.reference)
+      $0.uuid = .mock(uuids)
+    } operation: {
+      try await CheckSupervisionFlowStatus.resolve(
+        // appVersion non-nil => client knows the .requiresSubscription case
+        with: .init(vendorId: device.id.rawValue, code: claim.code, appVersion: "1.6.0"),
+        in: .mock,
+      )
+    }
+
+    expect(output).toEqual(.requiresSubscription(.init(
+      childId: child.id.rawValue,
+      token: uuids[1],
+      deviceId: device.id.rawValue,
+      childName: child.name,
+      supervised: .byGertrude(claimCode: claim.code),
+    )))
+  }
+
+  // old clients (no appVersion) can't decode .requiresSubscription, so keep returning .claimed
+  func testClaimedButUnpaid_oldClientWithoutAppVersion_staysClaimed() async throws {
+    let parent = try await self.parent() // no paid subscription
+    let child = try await self.db.create(Child.random { $0.parentId = parent.id })
+    let uuids = MockUUIDs()
+    let device = try await self.db.create(IOSDevice(
+      id: .init(),
+      childId: child.id,
+      modelIdentifier: "iPhone15,2",
+      iosVersion: "18.2",
+    ))
+    let claim = try await self.createClaim(
+      .blockerSupervise,
+      device.id,
+      child.id,
+      claimedAt: .reference,
+    )
+    try await self.db.create(BlockerApp.Install.mock { $0.deviceId = device.id })
+    try await self.db.create(BlockerApp.Supervision(deviceId: device.id))
+
+    let output = try await withDependencies {
+      $0.date = .constant(.reference)
+      $0.uuid = .mock(uuids)
+    } operation: {
+      try await CheckSupervisionFlowStatus.resolve(
+        with: .init(vendorId: device.id.rawValue, code: claim.code), // appVersion nil
+        in: .mock,
+      )
+    }
+
+    expect(output).toEqual(.claimed(.init(
+      childId: child.id.rawValue,
+      token: uuids[1],
+      deviceId: device.id.rawValue,
+      childName: child.name,
+      supervised: .byGertrude(claimCode: claim.code),
+    )))
+  }
+
   func testClaimed_notYetSupervised_expiredCode_renewsAndReturnsClaimed() async throws {
     let parent = try await self.parent()
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let uuids = MockUUIDs()
     let device = try await self.db.create(IOSDevice(
@@ -160,6 +240,7 @@ final class CheckSupervisionFlowStatusResolverTests: ApiTestCase, @unchecked Sen
 
   func testSupervised_notYetProfileInstalled() async throws {
     let parent = try await self.parent()
+    try await self.addLightPaidSubscription(for: parent.id)
     let child = try await self.db.create(Child.random { $0.parentId = parent.id })
     let device = try await self.db.create(IOSDevice(
       id: .init(),
@@ -185,7 +266,7 @@ final class CheckSupervisionFlowStatusResolverTests: ApiTestCase, @unchecked Sen
       $0.date = .constant(.reference)
     } operation: {
       try await CheckSupervisionFlowStatus.resolve(
-        with: .init(vendorId: device.id.rawValue, code: claim.code),
+        with: .init(vendorId: device.id.rawValue, code: claim.code, appVersion: "1.6.0"),
         in: .mock,
       )
     }
@@ -200,6 +281,86 @@ final class CheckSupervisionFlowStatusResolverTests: ApiTestCase, @unchecked Sen
       .where(.installId == install.id)
       .first(in: self.db)
     expect(data.token).toEqual(token.value.rawValue)
+  }
+
+  // supervised but profile not installed + lapsed plan: the profile artifact is
+  // payment-gated (ProfileDownload), so gate here too rather than dead-end in Safari
+  func testRequiresSubscription_supervisedButUnpaidNeedsProfile() async throws {
+    let parent = try await self.parent() // no paid subscription
+    let child = try await self.db.create(Child.random { $0.parentId = parent.id })
+    let uuids = MockUUIDs()
+    let device = try await self.db.create(IOSDevice(
+      id: .init(),
+      childId: child.id,
+      modelIdentifier: "iPhone15,2",
+      iosVersion: "18.2",
+    ))
+    let claim = try await self.createClaim(
+      .blockerSupervise,
+      device.id,
+      child.id,
+      claimedAt: .reference,
+    )
+    try await self.db.create(BlockerApp.Install.mock { $0.deviceId = device.id })
+    try await self.db.create(BlockerApp.Supervision(
+      deviceId: device.id,
+      supervisedAt: .reference, // supervised, but profileInstalledAt still nil
+    ))
+
+    let output = try await withDependencies {
+      $0.date = .constant(.reference)
+      $0.uuid = .mock(uuids)
+    } operation: {
+      try await CheckSupervisionFlowStatus.resolve(
+        with: .init(vendorId: device.id.rawValue, code: claim.code, appVersion: "1.6.0"),
+        in: .mock,
+      )
+    }
+
+    expect(output).toEqual(.requiresSubscription(.init(
+      childId: child.id.rawValue,
+      token: uuids[1],
+      deviceId: device.id.rawValue,
+      childName: child.name,
+      supervised: .byGertrude(claimCode: claim.code),
+    )))
+  }
+
+  // old clients (no appVersion) can't decode .requiresSubscription, so keep returning .missingProfile
+  func testMissingProfile_unpaidButOldClient_staysMissingProfile() async throws {
+    let parent = try await self.parent() // no paid subscription
+    let child = try await self.db.create(Child.random { $0.parentId = parent.id })
+    let device = try await self.db.create(IOSDevice(
+      id: .init(),
+      childId: child.id,
+      modelIdentifier: "iPhone15,2",
+      iosVersion: "18.2",
+    ))
+    let claim = try await self.createClaim(
+      .blockerSupervise,
+      device.id,
+      child.id,
+      claimedAt: .reference,
+    )
+    try await self.db.create(BlockerApp.Install.mock { $0.deviceId = device.id })
+    try await self.db.create(BlockerApp.Supervision(
+      deviceId: device.id,
+      supervisedAt: .reference,
+    ))
+
+    let output = try await withDependencies {
+      $0.date = .constant(.reference)
+    } operation: {
+      try await CheckSupervisionFlowStatus.resolve(
+        with: .init(vendorId: device.id.rawValue, code: claim.code), // appVersion nil
+        in: .mock,
+      )
+    }
+
+    guard case .missingProfile = output else {
+      XCTFail("Expected .missingProfile, got \(output)")
+      return
+    }
   }
 
   func testComplete_allFieldsSet() async throws {

--- a/swift/iosapp/lib-ios/Sources/LibApp/IOSReducer+BtnFallback.swift
+++ b/swift/iosapp/lib-ios/Sources/LibApp/IOSReducer+BtnFallback.swift
@@ -212,7 +212,7 @@ extension IOSReducer.Onboarding.Supervision.Resume {
     case (.networkError, _):
       .onboarding(.supervision(.resume(.networkError)))
     case (.requiresSubscription, _):
-      .onboarding(.supervision(.resume(.codeClaimedNotSupervised)))
+      .onboarding(.supervision(.resume(.requiresSubscription)))
     }
   }
 }

--- a/swift/iosapp/lib-ios/Sources/LibApp/IOSReducer+Launch.swift
+++ b/swift/iosapp/lib-ios/Sources/LibApp/IOSReducer+Launch.swift
@@ -11,6 +11,7 @@ extension IOSReducer.Deps {
       case codeNotClaimed(code: Int)
       case codeExpired
       case codeNotFound
+      case requiresSubscription(ChildIOSDeviceData_v2)
       case codeClaimedNotSupervised(ChildIOSDeviceData_v2)
       case supervisedButNeedsProfile(ChildIOSDeviceData_v2)
       // anomaly: api says "fully supervised", but filter is not running
@@ -45,6 +46,8 @@ extension IOSReducer.Deps {
           return .gertrudeSupervisionReboot(.codeExpired)
         case .notFound:
           return .gertrudeSupervisionReboot(.codeNotFound)
+        case .requiresSubscription(let conn):
+          return .gertrudeSupervisionReboot(.requiresSubscription(conn))
         case .claimed(let conn):
           return .gertrudeSupervisionReboot(.codeClaimedNotSupervised(conn))
         case .missingProfile(let conn):

--- a/swift/iosapp/lib-ios/Sources/LibApp/IOSReducer.swift
+++ b/swift/iosapp/lib-ios/Sources/LibApp/IOSReducer.swift
@@ -546,14 +546,9 @@ public struct IOSReducer {
       return .none
 
     case (.onboarding(.supervision(.resume(.codeClaimedNotSupervised))), .primary):
-      self.deps.log(state.screen, action, "f2729c3c")
-      if let code = self.deps.sharedStorage.loadPendingSupervisionCode()?.code {
-        state.screen = .onboarding(.supervision(.setup(.instructionsForProtector(code: code))))
-      } else {
-        self.deps.log(state.screen, action, "00b0c478", extra: "unreachable missing code")
-        state.screen = .onboarding(.supervision(.setup(.explainNeedSomeoneElse)))
-      }
-      return .none
+      self.deps.log(state.screen, action, "6dd407cb")
+      state.screen = .launching
+      return .send(.programmatic(.appDidLaunch))
 
     case (.onboarding(.supervision(.resume(.retrySupervision))), .primary):
       self.deps.log(state.screen, action, "d664b520")
@@ -649,8 +644,8 @@ public struct IOSReducer {
 
     case (.onboarding(.supervision(.resume(.requiresSubscription))), .primary):
       self.deps.log(state.screen, action, "b5e8076e")
-      state.screen = .onboarding(.supervision(.resume(.codeClaimedNotSupervised)))
-      return .none
+      state.screen = .launching
+      return .send(.programmatic(.appDidLaunch))
 
     // MARK: - error paths
 
@@ -781,6 +776,13 @@ public struct IOSReducer {
             deps.log("supervision reboot code not claimed", "e9b86e6b")
             await send(.programmatic(
               .setScreen(.onboarding(.supervision(.resume(.codeNotClaimed(code: code))))),
+            ))
+
+          case .gertrudeSupervisionReboot(.requiresSubscription(let conn)):
+            deps.log("supervision reboot requires subscription", "a7d41f0e")
+            await deps.receiveAccountConnection(conn)
+            await send(.programmatic(
+              .setScreen(.onboarding(.supervision(.resume(.requiresSubscription)))),
             ))
 
           case .gertrudeSupervisionReboot(.codeClaimedNotSupervised(let conn)):

--- a/swift/iosapp/lib-ios/Sources/LibClients/ApiClient.swift
+++ b/swift/iosapp/lib-ios/Sources/LibClients/ApiClient.swift
@@ -185,6 +185,7 @@ extension ApiClient: DependencyKey {
           unauthed: .checkSupervisionFlowStatus(.init(
             vendorId: deviceId,
             code: code,
+            appVersion: version,
           )),
         )
       },

--- a/swift/iosapp/lib-ios/Sources/LibViews/AppView.swift
+++ b/swift/iosapp/lib-ios/Sources/LibViews/AppView.swift
@@ -515,8 +515,8 @@ public struct AppView: View {
 
         case .onboarding(.supervision(.resume(.codeClaimedNotSupervised))):
           ButtonScreenView(
-            text: "We haven’t been able to confirm that this \(self.deviceType) is supervised yet. Supervision is required for Gertrude to manage this device — there’s no way to skip this step. If you’re having trouble, please contact us for help.",
-            primary: self.btn(text: "Retry supervision", .primary),
+            text: "We haven’t been able to confirm that this \(self.deviceType) is supervised yet. To finish, a parent needs to connect this \(self.deviceType) to a computer and complete supervision with the Gertrude supervision tool. Once that’s done, tap below to check again, or contact us if you’re stuck.",
+            primary: self.btn(text: "Check again", .primary),
             secondary: .init(text: "Contact support", type: .link(.support), animate: false),
           )
 

--- a/swift/iosapp/lib-ios/Tests/LibAppTests/IOSReducerTests+Launch.swift
+++ b/swift/iosapp/lib-ios/Tests/LibAppTests/IOSReducerTests+Launch.swift
@@ -104,6 +104,42 @@ final class IOSReducerTestsLaunch: XCTestCase {
   }
 
   @MainActor
+  func testSupervisionReboot_requiresSubscription() async throws {
+    let accountSet = LockIsolated(false)
+    let store = TestStore(initialState: IOSReducer.State()) {
+      IOSReducer()
+    } withDependencies: {
+      $0.device.deleteCacheFillDir = {}
+      $0.systemExtension.filterRunning = { false }
+      $0.sharedStorage.loadPendingSupervisionCode = { .mock }
+      $0.sharedStorage.loadFirstLaunchDate = { @Sendable in .distantPast }
+      $0.sharedStorage.saveAccountConnection = { @Sendable _ in }
+      $0.api.checkSupervisionFlowStatus = { @Sendable _ in .requiresSubscription(.mock) }
+      $0.api.setAccountConnection = { @Sendable _ in accountSet.setValue(true) }
+      $0.api.fetchAllBlockGroups = { @Sendable _ in [] }
+      $0.api.connectAccountFeatureFlag = { @Sendable in .init(isEnabled: true) }
+      $0.sharedStorage.migrateLegacyData = { @Sendable in false }
+      $0.sharedStorage.loadAllBlockGroups = { @Sendable in nil }
+      $0.sharedStorage.loadDisabledBlockGroupIds = { @Sendable in nil }
+      $0.sharedStorage.clearPendingSupervisionCode = { fatalError("not cleared") }
+    }
+
+    await store.send(.programmatic(.appDidLaunch))
+    await store.receive(.programmatic(.setFirstLaunch(.distantPast))) {
+      $0.onboarding.firstLaunch = .distantPast
+    }
+    await store.receive(.programmatic(
+      .setScreen(.onboarding(.supervision(.resume(.requiresSubscription)))),
+    )) {
+      $0.screen = .onboarding(.supervision(.resume(.requiresSubscription)))
+    }
+    await store.receive(.programmatic(.receivedConnectAccountFeatureFlag(.init(isEnabled: true)))) {
+      $0.onboarding.connectFeature = .init(isEnabled: true)
+    }
+    expect(accountSet.value).toEqual(true)
+  }
+
+  @MainActor
   func testSupervisionReboot_claimedNotSupervised() async throws {
     let accountSet = LockIsolated(false)
     let store = TestStore(initialState: IOSReducer.State()) {

--- a/swift/iosapp/lib-ios/Tests/LibAppTests/IOSReducerTests+Resume.swift
+++ b/swift/iosapp/lib-ios/Tests/LibAppTests/IOSReducerTests+Resume.swift
@@ -59,34 +59,67 @@ final class IOSReducerTestsResume: XCTestCase {
   }
 
   @MainActor
-  func testClaimedNotSupervised_withCode_goesToInstructions() async throws {
+  func testClaimedNotSupervised_reChecksServerAndAdvancesWhenSupervised() async throws {
     let store = TestStore(initialState: IOSReducer.State(
       screen: .onboarding(.supervision(.resume(.codeClaimedNotSupervised))),
     )) {
       IOSReducer()
     } withDependencies: {
-      $0.sharedStorage.loadPendingSupervisionCode = {
-        .init(code: 456, expiresAt: .reference)
-      }
+      $0.device.deleteCacheFillDir = {}
+      $0.systemExtension.filterRunning = { false }
+      $0.sharedStorage.loadPendingSupervisionCode = { .mock }
+      $0.sharedStorage.loadFirstLaunchDate = { @Sendable in .distantPast }
+      $0.sharedStorage.saveAccountConnection = { @Sendable _ in }
+      $0.api
+        .checkSupervisionFlowStatus = { @Sendable _ in .missingProfile(.mock) } // now supervised
+      $0.api.setAccountConnection = { @Sendable _ in }
+      $0.api.fetchAllBlockGroups = { @Sendable _ in [] }
+      $0.api.connectAccountFeatureFlag = { @Sendable in .init(isEnabled: true) }
+      $0.sharedStorage.migrateLegacyData = { @Sendable in false }
+      $0.sharedStorage.loadAllBlockGroups = { @Sendable in nil }
+      $0.sharedStorage.loadDisabledBlockGroupIds = { @Sendable in nil }
     }
+    store.exhaustivity = .off
 
     await store.send(.interactive(.onboardingBtnTapped(.primary, ""))) {
-      $0.screen = .onboarding(.supervision(.setup(.instructionsForProtector(code: 456))))
+      $0.screen = .launching // re-checks server instead of re-walking instructions
+    }
+    await store.receive(.programmatic(
+      .setScreen(.onboarding(.supervision(.resume(.promptInstallProfile)))),
+    )) {
+      $0.screen = .onboarding(.supervision(.resume(.promptInstallProfile)))
     }
   }
 
   @MainActor
-  func testClaimedNotSupervised_noCode_fallsBackToExplain() async throws {
+  func testRequiresSubscription_tryAgain_reChecksServerAfterPaying() async throws {
     let store = TestStore(initialState: IOSReducer.State(
-      screen: .onboarding(.supervision(.resume(.codeClaimedNotSupervised))),
+      screen: .onboarding(.supervision(.resume(.requiresSubscription))),
     )) {
       IOSReducer()
     } withDependencies: {
-      $0.sharedStorage.loadPendingSupervisionCode = { nil }
+      $0.device.deleteCacheFillDir = {}
+      $0.systemExtension.filterRunning = { false }
+      $0.sharedStorage.loadPendingSupervisionCode = { .mock }
+      $0.sharedStorage.loadFirstLaunchDate = { @Sendable in .distantPast }
+      $0.sharedStorage.saveAccountConnection = { @Sendable _ in }
+      $0.api.checkSupervisionFlowStatus = { @Sendable _ in .claimed(.mock) } // now paid
+      $0.api.setAccountConnection = { @Sendable _ in }
+      $0.api.fetchAllBlockGroups = { @Sendable _ in [] }
+      $0.api.connectAccountFeatureFlag = { @Sendable in .init(isEnabled: true) }
+      $0.sharedStorage.migrateLegacyData = { @Sendable in false }
+      $0.sharedStorage.loadAllBlockGroups = { @Sendable in nil }
+      $0.sharedStorage.loadDisabledBlockGroupIds = { @Sendable in nil }
     }
+    store.exhaustivity = .off
 
     await store.send(.interactive(.onboardingBtnTapped(.primary, ""))) {
-      $0.screen = .onboarding(.supervision(.setup(.explainNeedSomeoneElse)))
+      $0.screen = .launching
+    }
+    await store.receive(.programmatic(
+      .setScreen(.onboarding(.supervision(.resume(.codeClaimedNotSupervised)))),
+    )) {
+      $0.screen = .onboarding(.supervision(.resume(.codeClaimedNotSupervised)))
     }
   }
 

--- a/swift/iosapp/readme.md
+++ b/swift/iosapp/readme.md
@@ -11,6 +11,8 @@ LOCAL_API_URL = https:/$()/REPLACE.ngrok-free.app
 
 ## Release notes
 
+- `x.x.x` (dev)
+  - surface supervision payment gate helper screens
 - `1.8.3` (6/26/26)
   - connect free account uses claim-based flow, not code entry
   - expired supervision claim code now offers regenerate or start over

--- a/swift/pairql-iosapp/Sources/IOSRoute/UnauthedPairs/CheckSupervisionFlowStatus.swift
+++ b/swift/pairql-iosapp/Sources/IOSRoute/UnauthedPairs/CheckSupervisionFlowStatus.swift
@@ -7,10 +7,12 @@ public struct CheckSupervisionFlowStatus: Pair {
   public struct Input: PairInput {
     public var vendorId: UUID
     public var code: Int
+    public var appVersion: String?
 
-    public init(vendorId: UUID, code: Int) {
+    public init(vendorId: UUID, code: Int, appVersion: String? = nil) {
       self.vendorId = vendorId
       self.code = code
+      self.appVersion = appVersion
     }
   }
 
@@ -18,6 +20,7 @@ public struct CheckSupervisionFlowStatus: Pair {
     case pending
     case expired
     case notFound
+    case requiresSubscription(ChildIOSDeviceData_v2)
     case claimed(ChildIOSDeviceData_v2)
     case missingProfile(ChildIOSDeviceData_v2)
     case complete(ChildIOSDeviceData_v2)


### PR DESCRIPTION
This came out of working through a support issue and digging through the telemetry in the database a little bit and I realized that a modest number of people seem to have gotten in a little bit of a usability trap with the iOS blocker app and supervision where they needed their subscription to be in a paid state, and the dashboard would have given them that feedback, but the app itself didn't expose any clues that payment was the problem. In fact, there was even a screen I built at one point to show a bad payment state and I must have forgotten to wire it in or something, so this work was in some ways slightly done beforehand... but this just kind of makes the Blocker app more helpful and more resilient to payment issues during the setup process, which will hopefully help a few more people finish successfully. 