### PR TITLE
api: fix stripe tier upgrade overwrite bug, admin podcasts tweaks

### DIFF
--- a/swift/api/Sources/Api/PairQL/Admin/AdminSharedQuery.swift
+++ b/swift/api/Sources/Api/PairQL/Admin/AdminSharedQuery.swift
@@ -20,6 +20,7 @@ struct ParentData: Sendable {
   var numFilteringDisabledMacChildren: Int
   var numNotifications: Int
   var numIOSDevices: Int
+  var numConnectedPodcastApps: Int
   var hasCompletedSupervision: Bool
   var hasIncompleteSupervision: Bool
   var childActivityCount: Int
@@ -36,6 +37,7 @@ struct ParentData: Sendable {
     self.numFilteringDisabledMacChildren = 0
     self.numNotifications = 0
     self.numIOSDevices = 0
+    self.numConnectedPodcastApps = 0
     self.hasCompletedSupervision = false
     self.hasIncompleteSupervision = false
     self.childActivityCount = 0
@@ -133,6 +135,12 @@ struct AnalyticsData: Sendable {
       map[row.parentId] = row.iosDeviceCount
     }
 
+    let connectedPodcastAppCount = try await self.db.customQuery(ConnectedPodcastAppCount.self)
+    let connectedPodcastAppMap: [Parent.Id: Int] = connectedPodcastAppCount
+      .reduce(into: [:]) { map, row in
+        map[row.parentId] = row.connectedPodcastAppCount
+      }
+
     let activityCounts = try await self.db.customQuery(ActivityCounts.self)
     let activityMap: [Parent.Id: Int] = activityCounts.reduce(into: [:]) { map, row in
       map[row.parentId] = row.screenshotCount + row.keystrokeLineCount
@@ -164,6 +172,7 @@ struct AnalyticsData: Sendable {
       parent.numComputerUsers = computerUserMap[model.id] ?? 0
       parent.numFilteringDisabledMacChildren = filteringDisabledMacChildMap[model.id] ?? 0
       parent.numIOSDevices = iosDeviceMap[model.id] ?? 0
+      parent.numConnectedPodcastApps = connectedPodcastAppMap[model.id] ?? 0
       parent.hasCompletedSupervision = completedSupervisionSet.contains(model.id)
       parent.hasIncompleteSupervision = incompleteSupervisionSet.contains(model.id)
         && !completedSupervisionSet.contains(model.id)
@@ -199,6 +208,10 @@ extension ParentData {
 
   var hasConnectedFreeIOSDevice: Bool {
     self.numIOSDevices > 0 && !self.hasIncompleteSupervision
+  }
+
+  var hasConnectedPodcastApp: Bool {
+    self.numConnectedPodcastApps > 0
   }
 
   var status: ParentAnalyticsStatus {
@@ -342,6 +355,24 @@ struct IOSDeviceCount: CustomQueryable {
 
   var parentId: Parent.Id
   var iosDeviceCount: Int
+}
+
+struct ConnectedPodcastAppCount: CustomQueryable {
+  static func query(bindings: [Postgres.Data]) -> SQL.Statement {
+    .init("""
+    SELECT c.\(Child.columnName(.parentId)) AS parent_id,
+           COUNT(DISTINCT d.id)::int AS connected_podcast_app_count
+    FROM \(table: PodcastApp.Install.self) pai
+    JOIN \(table: IOSDevice.self) d
+      ON d.id = pai.\(PodcastApp.Install.columnName(.deviceId))
+    JOIN \(table: Child.self) c
+      ON c.id = d.\(IOSDevice.columnName(.childId))
+    GROUP BY c.\(Child.columnName(.parentId));
+    """)
+  }
+
+  var parentId: Parent.Id
+  var connectedPodcastAppCount: Int
 }
 
 struct SupervisionParents: CustomQueryable {

--- a/swift/api/Sources/Api/PairQL/Admin/Pairs/PodcastOverview.swift
+++ b/swift/api/Sources/Api/PairQL/Admin/Pairs/PodcastOverview.swift
@@ -1,4 +1,3 @@
-import Dependencies
 import DuetSQL
 import PairQL
 
@@ -26,14 +25,12 @@ struct PodcastOverview: Pair {
   struct RecentInstall: PairNestable {
     var date: Date
     var deviceType: String
-    var isPaid: Bool
+    var status: String
   }
 }
 
 extension PodcastOverview: NoInputResolver {
   static func resolve(in context: Context) async throws -> Output {
-    @Dependency(\.date.now) var now
-
     let iPhoneInstalls = try await context.db.count(
       DeviceTypeInstallCount.self,
       withBindings: [.string("27c4f26a"), .string("%iPhone%")],
@@ -45,7 +42,7 @@ extension PodcastOverview: NoInputResolver {
 
     let activePodcastUsers = try await context.db.count(ActivePodcastUsersCount.self)
 
-    let statusRows = try await context.db.customQuery(InstallStatusRowsQuery.self)
+    let statusRows = try await context.db.customQuery(StatusBreakdownRowsQuery.self)
     var breakdown = StatusBreakdown(
       paid: 0,
       complimentary: 0,
@@ -55,35 +52,29 @@ extension PodcastOverview: NoInputResolver {
       iap: 0,
     )
     for row in statusRows {
-      switch try await PodcastInstallsList.status(
-        deviceId: row.deviceId,
-        firstLaunch: row.firstLaunch,
-        connected: row.connected,
-        isPaid: row.isPaid,
-        at: now,
-        in: context,
-      ) {
-      case "paid": breakdown.paid += 1
-      case "complimentary": breakdown.complimentary += 1
-      case "connected": breakdown.connected += 1
-      case "trial": breakdown.trial += 1
-      case "expired": breakdown.expired += 1
-      case "iap": breakdown.iap += 1
+      switch row.status {
+      case "paid": breakdown.paid += row.count
+      case "complimentary": breakdown.complimentary += row.count
+      case "connected": breakdown.connected += row.count
+      case "trial": breakdown.trial += row.count
+      case "expired": breakdown.expired += row.count
+      case "iap": breakdown.iap += row.count
       default: break
       }
     }
+    let totalInstalls = statusRows.reduce(0) { $0 + $1.count }
 
-    let recentInstalls = try await context.db.customQuery(RecentInstallsQuery.self)
-      .map { row in
-        RecentInstall(
-          date: row.date,
-          deviceType: ModelIdentifier.deviceType(from: row.modelIdentifier),
-          isPaid: row.isPaid,
-        )
-      }
+    let recentRows = try await context.db.customQuery(RecentInstallsQuery.self)
+    let recentInstalls = recentRows.map { row in
+      RecentInstall(
+        date: row.date,
+        deviceType: ModelIdentifier.deviceType(from: row.modelIdentifier),
+        status: row.status,
+      )
+    }
 
     return .init(
-      totalInstalls: statusRows.count,
+      totalInstalls: totalInstalls,
       activePodcastUsers: activePodcastUsers,
       iPhoneInstalls: iPhoneInstalls,
       iPadInstalls: iPadInstalls,
@@ -93,38 +84,58 @@ extension PodcastOverview: NoInputResolver {
   }
 }
 
-private struct InstallStatusRowsQuery: CustomQueryable {
+private struct StatusBreakdownRowsQuery: CustomQueryable {
   static func query(bindings: [Postgres.Data]) -> SQL.Statement {
     let deviceId = PodcastEvent.columnName(.deviceId)
     let eventId = PodcastEvent.columnName(.eventId)
     let createdAt = PodcastEvent.columnName(.createdAt)
     let devPk = IOSDevice.columnName(.id)
     let devChildId = IOSDevice.columnName(.childId)
+    let childPk = Child.columnName(.id)
+    let childParentId = Child.columnName(.parentId)
+    let subParentId = StripeSubscription.columnName(.parentId)
+    let subStatus = StripeSubscription.columnName(.stripeStatus)
+    let billingParentId = BillingIdentity.columnName(.parentId)
+    let billingComplimentary = BillingIdentity.columnName(.isComplimentary)
     return SQL.Statement("""
+    WITH install_statuses AS (
+      SELECT
+        CASE
+          WHEN billing.\(billingComplimentary) = true THEN 'complimentary'
+          WHEN sub.\(subStatus) IN ('active', 'past_due') THEN 'paid'
+          WHEN dev.\(devChildId) IS NOT NULL THEN 'connected'
+          WHEN paid.\(deviceId) IS NOT NULL THEN 'iap'
+          WHEN first_launch.\(createdAt) + INTERVAL '30 days' > NOW() THEN 'trial'
+          ELSE 'expired'
+        END AS status
+      FROM (
+        SELECT DISTINCT ON (\(deviceId)) \(deviceId), \(createdAt)
+        FROM \(table: PodcastEvent.self)
+        WHERE \(eventId) = '27c4f26a'
+        ORDER BY \(deviceId), \(createdAt) ASC
+      ) first_launch
+      LEFT JOIN (
+        SELECT DISTINCT \(deviceId)
+        FROM \(table: PodcastEvent.self)
+        WHERE \(hostPurchasePodcastEventPredicateSQL)
+      ) paid ON first_launch.\(deviceId) = paid.\(deviceId)
+      LEFT JOIN \(table: IOSDevice.self) dev ON dev.\(devPk) = first_launch.\(deviceId)
+      LEFT JOIN \(table: Child.self) child ON child.\(childPk) = dev.\(devChildId)
+      LEFT JOIN \(table: StripeSubscription.self) sub
+        ON sub.\(subParentId) = child.\(childParentId)
+      LEFT JOIN \(table: BillingIdentity.self) billing
+        ON billing.\(billingParentId) = child.\(childParentId)
+    )
     SELECT
-      first_launch.\(deviceId),
-      first_launch.\(createdAt) AS first_launch,
-      CASE WHEN paid.\(deviceId) IS NOT NULL THEN true ELSE false END AS is_paid,
-      CASE WHEN dev.\(devChildId) IS NOT NULL THEN true ELSE false END AS connected
-    FROM (
-      SELECT DISTINCT ON (\(deviceId)) \(deviceId), \(createdAt)
-      FROM \(table: PodcastEvent.self)
-      WHERE \(eventId) = '27c4f26a'
-      ORDER BY \(deviceId), \(createdAt) ASC
-    ) first_launch
-    LEFT JOIN (
-      SELECT DISTINCT \(deviceId)
-      FROM \(table: PodcastEvent.self)
-      WHERE \(hostPurchasePodcastEventPredicateSQL)
-    ) paid ON first_launch.\(deviceId) = paid.\(deviceId)
-    LEFT JOIN \(table: IOSDevice.self) dev ON dev.\(devPk) = first_launch.\(deviceId)
+      status,
+      COUNT(*)::int AS count
+    FROM install_statuses
+    GROUP BY status
     """)
   }
 
-  var deviceId: UUID
-  var firstLaunch: Date
-  var isPaid: Bool
-  var connected: Bool
+  var status: String
+  var count: Int
 }
 
 private struct DeviceTypeInstallCount: CustomCountable {
@@ -154,29 +165,38 @@ private struct RecentInstallsQuery: CustomQueryable {
     let eventId = PodcastEvent.columnName(.eventId)
     let createdAt = PodcastEvent.columnName(.createdAt)
     let modelIdentifier = PodcastEvent.columnName(.modelIdentifier)
+    let devPk = IOSDevice.columnName(.id)
+    let devChildId = IOSDevice.columnName(.childId)
+    let childPk = Child.columnName(.id)
+    let childParentId = Child.columnName(.parentId)
+    let subParentId = StripeSubscription.columnName(.parentId)
+    let subStatus = StripeSubscription.columnName(.stripeStatus)
     return SQL.Statement("""
     SELECT
       first_launch.\(createdAt) AS date,
       first_launch.\(modelIdentifier) AS model_identifier,
-      CASE WHEN paid.\(deviceId) IS NOT NULL THEN TRUE ELSE FALSE END AS is_paid
+      CASE
+        WHEN dev.\(devChildId) IS NULL THEN 'trial'
+        WHEN sub.\(subStatus) IN ('active', 'past_due') THEN 'paid'
+        ELSE 'connected'
+      END AS status
     FROM (
       SELECT DISTINCT ON (\(deviceId)) \(deviceId), \(createdAt), \(modelIdentifier)
       FROM \(table: PodcastEvent.self)
       WHERE \(eventId) = '27c4f26a'
       ORDER BY \(deviceId), \(createdAt)
     ) first_launch
-    LEFT JOIN (
-      SELECT DISTINCT \(deviceId)
-      FROM \(table: PodcastEvent.self)
-      WHERE \(hostPurchasePodcastEventPredicateSQL)
-    ) paid ON first_launch.\(deviceId) = paid.\(deviceId)
+    LEFT JOIN \(table: IOSDevice.self) dev ON dev.\(devPk) = first_launch.\(deviceId)
+    LEFT JOIN \(table: Child.self) child ON child.\(childPk) = dev.\(devChildId)
+    LEFT JOIN \(table: StripeSubscription.self) sub
+      ON sub.\(subParentId) = child.\(childParentId)
     ORDER BY first_launch.\(createdAt) DESC
     """)
   }
 
   var date: Date
   var modelIdentifier: String
-  var isPaid: Bool
+  var status: String
 }
 
 private struct ActivePodcastUsersCount: CustomCountable {

--- a/swift/api/Sources/Api/PairQL/Admin/Pairs/SubscriptionsOverview.swift
+++ b/swift/api/Sources/Api/PairQL/Admin/Pairs/SubscriptionsOverview.swift
@@ -68,7 +68,8 @@ extension SubscriptionsOverview: NoInputResolver {
       let engagement =
         if parent.isActive
           || parent.hasCompletedSupervision
-          || parent.hasConnectedFreeIOSDevice {
+          || parent.hasConnectedFreeIOSDevice
+          || parent.hasConnectedPodcastApp {
           "engaged"
         } else if parent.numComputerUsers > 0 || parent.hasIncompleteSupervision {
           "partial"

--- a/swift/api/Sources/Api/Routes/StripeEvents.swift
+++ b/swift/api/Sources/Api/Routes/StripeEvents.swift
@@ -109,7 +109,14 @@ private func handleInvoicePaid(
     return
   }
 
-  let priceId = event?.data?.object?.lines?.data?.first?.price?.id
+  // proration invoices can list the old plan's credit line before the new plan's charge;
+  // pick the tier-recognized line, preferring non-proration among matches
+  let lines = event?.data?.object?.lines?.data ?? []
+  let planLines = lines
+    .filter { $0.price?.id.flatMap(StripeSubscription.Tier.init(stripePriceId:)) != nil }
+  let currentPlanLine = planLines.first(where: { $0.proration != true }) ?? planLines.first
+
+  let priceId = currentPlanLine?.price?.id
   guard let eventTier = priceId.flatMap(StripeSubscription.Tier.init(stripePriceId:)) else {
     unexpected("bf3cad72", detail: "email: \(email ?? "(nil)"), event: \(stripeEvent.id)")
     return
@@ -121,7 +128,7 @@ private func handleInvoicePaid(
   }
 
   let now = get(dependency: \.date.now)
-  let periodEnd = event?.data?.object?.lines?.data?.first?.period?.end
+  let periodEnd = currentPlanLine?.period?.end
     .map { Date(timeIntervalSince1970: TimeInterval($0)) }
     ?? now + .days(eventTier.periodLengthInDays)
 
@@ -332,6 +339,7 @@ private struct EventInfo: Decodable {
 
           var period: Period?
           var price: Price?
+          var proration: Bool?
         }
 
         var data: [Line]?

--- a/swift/api/Tests/ApiTests/StripeEventTests.swift
+++ b/swift/api/Tests/ApiTests/StripeEventTests.swift
@@ -587,6 +587,94 @@ final class StripeEventTests: ApiTestCase, @unchecked Sendable {
     expect(alarms.count).toEqual(1)
   }
 
+  func testUpgradeProrationInvoiceUsesNewPlanNotCreditLine() async throws {
+    let subscriptionId: StripeSubscription.StripeId = .init("subId_".random)
+    let parent = try await self.parentWithSubscription { _, sub in
+      sub.tier = .light
+      sub.stripeId = subscriptionId
+    }
+    let newPeriodEnd = 1_704_050_627
+    let oldPeriodEnd = 1_800_000_000
+
+    let json = """
+      {
+        "type": "invoice.paid",
+        "data": {
+          "object": {
+            "amount_due": 155,
+            "customer_email": "\(parent.email)",
+            "subscription": "\(subscriptionId.rawValue)",
+            "lines": {
+              "data": [
+                {
+                  "price": { "id": "\(self.env.stripe.priceIdLight)" },
+                  "period": { "end": \(oldPeriodEnd), "start": 1701372227 },
+                  "proration": true
+                },
+                {
+                  "price": { "id": "\(self.env.stripe.priceIdFull)" },
+                  "period": { "end": \(newPeriodEnd), "start": 1701372227 },
+                  "proration": false
+                }
+              ]
+            }
+          }
+        }
+      }
+    """
+
+    try await app.test(.POST, "stripe-events", body: .init(string: json), afterResponse: { res in
+      expect(res.status).toEqual(.noContent)
+      let retrieved = try await parent.model.subscription(in: self.db)!
+      expect(retrieved.tier).toEqual(.full) // <-- not .light, from the credit line
+      expect(retrieved.currentPeriodEnd)
+        .toEqual(Date(timeIntervalSince1970: TimeInterval(newPeriodEnd)))
+    })
+  }
+
+  func testUnrelatedNonProrationLineDoesNotMaskThePlanLine() async throws {
+    let subscriptionId: StripeSubscription.StripeId = .init("subId_".random)
+    let parent = try await self.parentWithSubscription { _, sub in
+      sub.tier = .light
+      sub.stripeId = subscriptionId
+    }
+    let periodEnd = 1_704_050_627
+
+    let json = """
+      {
+        "type": "invoice.paid",
+        "data": {
+          "object": {
+            "amount_due": 1155,
+            "customer_email": "\(parent.email)",
+            "subscription": "\(subscriptionId.rawValue)",
+            "lines": {
+              "data": [
+                {
+                  "price": { "id": "price_unrelated_addon" },
+                  "proration": false
+                },
+                {
+                  "price": { "id": "\(self.env.stripe.priceIdFull)" },
+                  "period": { "end": \(periodEnd), "start": 1701372227 },
+                  "proration": false
+                }
+              ]
+            }
+          }
+        }
+      }
+    """
+
+    try await app.test(.POST, "stripe-events", body: .init(string: json), afterResponse: { res in
+      expect(res.status).toEqual(.noContent)
+      let retrieved = try await parent.model.subscription(in: self.db)!
+      expect(retrieved.tier).toEqual(.full) // <-- not bailed out on the unrelated add-on line
+      expect(retrieved.currentPeriodEnd)
+        .toEqual(Date(timeIntervalSince1970: TimeInterval(periodEnd)))
+    })
+  }
+
   func testZeroAmountDueInvoicePaidDoesNotOverrideCancelledStatus() async throws {
     let subscriptionId: StripeSubscription.StripeId = .init("subId_".random)
     let parent = try await self.parentWithSubscription { _, sub in

--- a/web/admin/src/components/PodcastInstallsGraph.tsx
+++ b/web/admin/src/components/PodcastInstallsGraph.tsx
@@ -4,7 +4,7 @@ import TimeSeriesGraph from './TimeSeriesGraph';
 interface Install {
   date: string;
   deviceType: string;
-  isPaid: boolean;
+  status: string;
 }
 
 interface PodcastInstallsGraphProps {
@@ -14,7 +14,7 @@ interface PodcastInstallsGraphProps {
 const PodcastInstallsGraph: React.FC<PodcastInstallsGraphProps> = ({ installs }) => {
   const items = installs.map((install) => ({
     date: install.date,
-    status: install.isPaid ? `paid` : `free`,
+    status: install.status,
     label: install.deviceType,
   }));
 
@@ -25,7 +25,7 @@ const PodcastInstallsGraph: React.FC<PodcastInstallsGraphProps> = ({ installs })
       gradient="green"
       statusConfig={{
         isSuccess: (status) => status === `paid`,
-        isWarning: () => false,
+        isWarning: (status) => status === `connected`,
       }}
       twoColumnTooltip
     />

--- a/web/admin/src/pages/Dashboard.tsx
+++ b/web/admin/src/pages/Dashboard.tsx
@@ -214,7 +214,7 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
   const freeCount =
     data.totalAccounts - data.fullPlanCount - data.lightPlanCount - data.trialingCount;
   // monthly compensation from living room
-  const LIVING_ROOM_MONTHLY = 125;
+  const LIVING_ROOM_MONTHLY = 150;
   const stats = [
     {
       label: `Protected People`,

--- a/web/shared/pairql/src/admin/pairs/PodcastOverview.ts
+++ b/web/shared/pairql/src/admin/pairs/PodcastOverview.ts
@@ -18,7 +18,7 @@ export namespace PodcastOverview {
     recentInstalls: Array<{
       date: ISODateString;
       deviceType: string;
-      isPaid: boolean;
+      status: string;
     }>;
   }
 }


### PR DESCRIPTION
had a user upgrade from light to full a few days ago, but noticed our full count didn't seem to go up, found a bug relating to the processing of webhook data, this fixes it.

then, added a little more clarity about podcast subcription/success metrics for the admin site