### PR TITLE
monorepo: document spm shared package organization

### DIFF
--- a/docs/notes/009-gertie-shared-module-structure.md
+++ b/docs/notes/009-gertie-shared-module-structure.md
@@ -1,0 +1,132 @@
+# 009 — Gertie shared Swift module structure
+
+_Date: 2026-06-19 (decided 2026-06-17, shipped in PR #751 `blocker-crosspromo`)._
+
+> **Read this before creating a new SPM package or target, or whenever you're unsure where
+> a shared Swift type or feature belongs.** It gives the semantic purpose of each shared
+> module and the rule for choosing a new _target_ vs a new _package_.
+
+## The module map
+
+Two packages hold code shared across the Gertrude apps. Everything else (`api`, `macapp`,
+`iosapp`, `podcasts`, `music`, the `pairql-*` route packages, the `x-*` utilities)
+consumes them.
+
+### `swift/gertie` — shared DATA / types (dependency-light, server-safe, TCA-free)
+
+One package, several independent **targets**. Platform floor `macOS .v10_15 / iOS .v17`,
+swift-tools 6.0. This is the monorepo's cross-cutting container for shared _types_; add
+new targets freely.
+
+- **`Gertie`** — the core, cross-platform parental-controls domain: `BlockRule`,
+  `RuleKeychain` / `RuleSchedule`, `FilterSuspension`, `SecurityEvent`, `NetworkDecision`,
+  `AppScope` / `AppDescriptor`, `UserFilterState`, and friends. The shared filtering /
+  monitoring vocabulary. Consumed by `api`, `macapp`, and the `iosapp` blocker.
+- **`GertieBlocker`** — the **blocker app's** domain specifically: `BlockGroup`,
+  `WebContentFilterPolicy`, and blocker-only extensions. Re-exports `Gertie` (see
+  `Exports.swift` below), so a `GertieBlocker` consumer sees the core types too. Consumed
+  by `api` (~30 files) and the `iosapp` blocker. (This is the renamed old `GertieIOS` —
+  see naming below.)
+- **`GertieApp`** — **cross-app wire types** shared by _all_ the apps plus the server:
+  every iOS app (blocker, podcasts / AM, music), the Mac app, and the `api`. First tenant
+  is the cross-promotion campaign model (`CrossPromoCampaign` and its CTA / action / style
+  / image family, plus the lossy forward-compat decoder). **Zero dependencies, plain
+  `Codable`** — keep it that way. This is where a type shared _across the app family_
+  goes.
+
+### `swift/gertie-tca-features` — shared BEHAVIOR (client TCA apps only)
+
+Product `GertieTcaFeatures`. Platform floor `macOS .v15 / iOS .v17`, swift-tools 6.1;
+depends on `GertieApp` + The Composable Architecture + swift-dependencies. Holds shared
+_reducers_ and TCA-adjacent helpers: the `CrossPromoFeature` reducer, the `SharePresenter`
+(UIKit share sheet), and campaign-behavior helpers. Consumed by the client TCA apps only
+(`iosapp/lib-ios`, `podcasts/lib-tca`, and the future music app) — **never by the `api`.**
+
+Mental model: **`gertie` = shared data; `gertie-tca-features` = shared behavior.**
+
+## The rule: new _target_ vs new _package_
+
+The load-bearing fact is a subtlety of SwiftPM:
+
+> SwiftPM compiles **per target**, but resolves dependencies and platform floors **per
+> package.** A consumer that imports just one product of a package still inherits that
+> whole package's dependency graph and minimum platform during resolution.
+
+So:
+
+- **Default: add a new _target_ under `swift/gertie`.** Because compilation is per-target,
+  a music app can `import GertieApp` without compiling `GertieBlocker`'s filtering domain.
+  New shared types are cheap this way — no new package, and no new dependency imposed on
+  anyone.
+- **Reach for a new _package_ only when a chunk needs a heavy / opinionated dependency (or
+  a higher platform floor) you don't want imposed on every `gertie` consumer — above all
+  the API server.** TCA is the canonical trip-wire: putting it in `gertie` would force
+  `api` (Linux, no TCA, low platform floor) and `macapp` to resolve a client-UI framework
+  and risk version-pin conflicts. That is exactly why `gertie-tca-features` is its own
+  package.
+
+Keep `gertie` dependency-light, server-safe (`macOS .v10_15`), and TCA-free. Keep the
+`api` off `gertie-tca-features`.
+
+## Why the shared wire types are a _target in `gertie`_, not a standalone package
+
+This was the live decision, and it was made twice:
+
+1. The work started with a planned standalone `swift/crosspromo` package (matching the
+   `swift/x-*` convention). It was **folded into `gertie` as the `GertieApp` target** once
+   the "one family-wide bucket to pull from" principle was affirmed — a music app
+   depending on `gertie` is fine, and per-target compilation keeps the filtering domain
+   out of its build.
+2. A dependency conflict then tempted a re-split: `podcasts/lib-tca` (Gertrude AM)
+   hard-requires `swift-tagged >= 0.10.0` (via the `StructuredQueriesTagged` trait), while
+   the monorepo's `jaredh159/swift-tagged` fork was pinned at `0.8.2`. Since consuming
+   _any_ `gertie` product drags gertie's fork dependency into AM's solve, one fix was to
+   extract `GertieApp` into its own zero-dep `swift/gertie-app` package. **That was
+   considered and rejected:** instead the fork was bumped to `0.10.1` (mainline `0.10.0` +
+   the two fork patches), keeping `GertieApp` a target inside `gertie`. **We preserved the
+   layout and fixed the dependency.** (The fork exists for its lowercase-UUID encoding
+   patch; do not migrate the repo to mainline swift-tagged.)
+
+## Naming
+
+- **`GertieIOS` → `GertieBlocker`.** The old name read as "iOS-platform code" or "shared
+  iOS-apps code," but the target is actually the _blocker app's_ domain (and the server
+  imports it heavily). The rename tells the truth and freed the namespace for a genuinely
+  shared module.
+- **`GertieApp` is scoped to include the Mac app and the server** — hence "App," not
+  "IOS." Its wire types are family-wide (all iOS apps + Mac + `api`). `GertieIOS` would
+  have excluded the Mac app and forced a rename the day it adopts a cross-app feature.
+- **Lean into `podcast` / `blocker` / `music` at call sites**, not "iOS app." There are
+  now three iOS apps; "the iOS app" is no longer a synonym for the blocker. (E.g. the api
+  resolvers are `PodcastCrossPromos` / `BlockerCrossPromos`, not one ambiguous
+  `CrossPromos`.)
+
+## Conventions that fell out of this
+
+- **Re-export moved types with `@_exported import` in an `Exports.swift`.** When shared
+  types move into `GertieApp`, a route module can re-export them so existing
+  `import PodcastRoute` (etc.) consumers keep seeing them with no import churn.
+  Established idiom: `GertieBlocker` re-exports `Gertie`; `MacAppRoute` re-exports
+  `PairQL`.
+- **Views are never shared.** iOS uses SwiftUI; the Mac app uses a webview + React. Share
+  reducers and types, not views.
+- **Share the wire types + reducer + server catalog; duplicate the rest on purpose.** Each
+  app keeps its own view, its own persistence, its own PairQL pair, its own root-reducer
+  wiring, and its own placement / string constants. A shared abstraction over those was
+  judged net-negative.
+
+## What this means for new code
+
+- A **type shared by two or more apps (or an app and the server)** → `GertieApp` (plain
+  `Codable`, no heavy deps). A distinct shared _domain_ can be its own new target under
+  `gertie`.
+- A **blocker-specific type the server also needs** → `GertieBlocker`. Core cross-platform
+  parental-controls domain → `Gertie`.
+- **Shared TCA behavior** (a reducer / feature for the client apps) →
+  `gertie-tca-features` (`GertieTcaFeatures`). Never make the `api` depend on it.
+- **Only mint a new package** when a shared chunk needs a dependency or platform floor you
+  don't want imposed on all of `gertie`'s consumers (especially the server). Otherwise a
+  new **target** under `gertie` is the answer. Don't add TCA or other heavy deps to
+  `gertie`.
+- Adding a shared SPM package requires nx registration (a `project.json`, mirroring an
+  existing package); run `pnpm exec nx reset` from `swift/` after adding.

--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -7,10 +7,10 @@ all notes.
   — replaces a glob-masquerading-as-regex with `NSRegularExpression`/`RegExp` end-to-end
   (`caseInsensitive` on both); in-place upgrade rather than a new key type.
 
-- **[002 — Throttling Mac app icon refreshes](./002-macapp-icon-refresh.md)** — icon
-  upload eligibility now keyed on missing-or-stale freshness (with version-aware
-  preference for newer app builds), not naive hash mismatch; adds `icon_uploaded_at` +
-  `icon_source_app_version` to `macos.mac_apps`.
+- **[002 — Throttling Mac app icon refreshes](./002-macapp-icon-refresh.md)** —
+  icon-upload eligibility keyed on missing-or-stale freshness (version-aware preference
+  for newer builds), not naive hash mismatch; adds `icon_uploaded_at` +
+  `icon_source_app_version`.
 
 - **[003 — Screenshot timer lifecycle](./003-macapp-screenshot-bursts.md)** — moves the
   Mac app screenshot timer out of a TCA `.cancellable(cancelInFlight:)` effect into a
@@ -18,10 +18,9 @@ all notes.
   concurrent timers (cause of 10–12/sec screenshot bursts under Fast User Switching).
 
 - **[004 — Stripe billing overhaul](./004-stripe-billing-overhaul.md)** — three-layer
-  billing model (`BillingIdentity` / `StripeSubscription` / `BillingAccountSnapshot`),
-  action-based subscription panel (`primary`/`secondary` from the server), reconciling
-  webhook; fixes the duplicate-customer and reactivation classes of bugs by separating
-  entitlement from billing substrate.
+  billing model (`BillingIdentity` / `StripeSubscription` / `BillingAccountSnapshot`)
+  separating entitlement from billing substrate; kills the duplicate-customer and
+  reactivation bug classes.
 
 - **[005 — `vendorId` / `deviceId` / `installId` naming](./005-vendor-id-device-id-naming.md)**
   — naming convention for cross-app physical-device identity: `vendorId` only at the
@@ -29,18 +28,21 @@ all notes.
   is a server-internal per-app install-row PK.
 
 - **[006 — Capabilities derive from the billing snapshot](./006-capabilities-from-snapshot.md)**
-  — capabilities come from `BillingAccountSnapshot` as a union of entitlements (per-tier
-  table), not the lossy `PlanStatus` projection; `substrate: PaidSubscription?` added to
-  trial cases to make the projection lossless; Medium-tier-ready by design.
+  — capabilities are a union of entitlements from `BillingAccountSnapshot` (per-tier
+  table), not the lossy `PlanStatus` projection; Medium-tier-ready by design.
 
 - **[007 — Measuring marketing campaigns without a held-back cohort](./007-marketing-campaign-measurement.md)**
-  — deliberately no holdout/cohort or A/B machinery: at ~800 accounts / ~117 backlog a
-  control arm can't reach significance, so we throttle (manual waves, daily cadence),
-  capture a `variant` for copy reconstruction, and lean on near-zero base rates + replies
-  for directional, judgment-based reads.
+  — deliberately no holdout/A-B machinery (too few accounts for significance); instead
+  throttle to manual daily waves, capture a `variant`, and read directionally from
+  near-zero base rates + replies.
 
 - **[008 — `child.claims` table and `ClaimIntent`: first-class claim model](./008-claims-table-and-intent.md)**
   — replaces three `ios_devices` columns with a dedicated claims table carrying a
-  `ClaimIntent` enum; enables per-funnel intent verification and helpful cross-app rejection
-  messages; partial unique index enforces at most one active unclaimed code per
-  (device, intent).
+  `ClaimIntent` enum; enables per-funnel intent verification and at-most-one-active-code
+  enforcement.
+
+- **[009 — Gertie shared Swift module structure](./009-gertie-shared-module-structure.md)**
+  — semantic map of the shared Swift modules (`Gertie` / `GertieBlocker` / `GertieApp` =
+  shared data; `gertie-tca-features` = shared TCA behavior) and the
+  new-**target**-vs-new-**package** rule. Read before creating a new SPM module, or when
+  unsure where to place shared functionality.

--- a/swift/AGENTS.md
+++ b/swift/AGENTS.md
@@ -34,17 +34,21 @@ files when a file grows too large or when a clear organizational seam emerges.
 
 ```
 swift/
-├── api/               # Vapor 4 API server (PostgreSQL db)
-├── macapp/            # macOS app
-├── iosapp/            # iOS app
-├── gertie/            # Core domain models (shared across platforms)
-├── duet/              # Custom lightweight ORM
-├── pairql/            # Type-safe RPC core library
-├── pairql-macapp/     # macOS API pairql route definitions
-├── pairql-iosapp/     # iOS API pairql route definitions
-├── pairql-podcasts/   # Podcast app (not in monorepo) pairql API routes
-├── ts-interop/        # TypeScript code generation
-└── docs/              # Documentation
+├── api/                  # Vapor 4 API server (PostgreSQL db)
+├── macapp/               # macOS app
+├── iosapp/               # iOS content-filter app (the "blocker")
+├── podcasts/             # Gertrude AM podcast app
+├── music/                # Gertrude Music app (private beta)
+├── gertie/               # Shared data/types: Gertie, GertieBlocker, GertieApp targets
+├── gertie-tca-features/  # Shared TCA reducers/behavior (client apps only, not the api)
+├── duet/                 # Custom lightweight ORM
+├── pairql/               # Type-safe RPC core library
+├── pairql-macapp/        # macOS API pairql route definitions
+├── pairql-iosapp/        # iOS (blocker) API pairql route definitions
+├── pairql-podcasts/      # Podcast app (Gertrude AM) pairql route definitions
+├── pairql-music/         # Music app pairql route definitions
+├── ts-interop/           # TypeScript code generation
+└── docs/                 # Documentation
 ```
 
 ## The Three Main Applications
@@ -176,10 +180,29 @@ searches, and more
 
 ## Core Shared Libraries
 
-### `gertie/` - Domain Models
+> **Where does a shared type or feature go? When should you mint a new SPM package vs a new
+> target?** Read
+> [`../docs/notes/009-gertie-shared-module-structure.md`](../docs/notes/009-gertie-shared-module-structure.md)
+> before adding a shared module or if you're unsure where something belongs. In short: new
+> shared _types_ default to a new **target** under `gertie`; a new **package** is only for
+> code needing a dependency or platform floor you don't want imposed on every consumer
+> (especially the API server) — which is why the TCA features live in their own package.
 
-- **Purpose:** Core domain types shared across macOS, iOS, and API
-- **Products:** `Gertie`, `GertieBlocker`
+### `gertie/` - Shared data / types
+
+- **Purpose:** The cross-cutting container for shared Swift _data types_ — dependency-light,
+  server-safe, TCA-free. One package, several independent targets; add new targets freely.
+- **Products:** `Gertie` (core cross-platform parental-controls domain), `GertieBlocker`
+  (blocker-app domain; re-exports `Gertie`), `GertieApp` (cross-app wire types shared by all
+  apps + the server).
+
+### `gertie-tca-features/` - Shared TCA behavior
+
+- **Purpose:** Shared TCA reducers/features for the client apps (e.g. `CrossPromoFeature`,
+  `SharePresenter`). A separate package because it depends on TCA — kept out of `gertie` so
+  the API server and macapp never resolve it. Consumed by client TCA apps only, **never the
+  `api`.**
+- **Product:** `GertieTcaFeatures`
 
 ### `duet/` - Custom ORM
 


### PR DESCRIPTION
Working on a couple of my tasks, I realized that I had sort of lost my own memory of how I decided to like reorganize and think about shared SPM modules for the iOS apps, and so I went back and created this note and updated the agent docs. If you're doing anything related to extracting Shared iOS stuff, you should probably pull this in right away and make sure that you're sort of following along with the correct convention, or maybe let me know if for any reason the conventions don't seem to hold up in the work that you're doing, and we could address it together. 