### PR TITLE
api,music: improve music logging

### DIFF
--- a/swift/api/Sources/Api/PairQL/IOSApps/EventLabels/EventLabels+Music.swift
+++ b/swift/api/Sources/Api/PairQL/IOSApps/EventLabels/EventLabels+Music.swift
@@ -18,6 +18,7 @@ extension EventLabel {
     case "ffbbb03c": "Onboarding claim code shown"
     case "9b438d26": "Onboarding device recognized (no claim needed)"
     case "8af8b414": "Onboarding setup completed"
+    case "9cfe15f7": "Returning launch"
     // --- Subscription ---
     case "bfa4b9e6": "Apple Music subscription required"
     case "e1c0d002": "Apple Music subscription status unavailable"

--- a/swift/api/Sources/Api/PairQL/IOSApps/LogAppEvent+Music.swift
+++ b/swift/api/Sources/Api/PairQL/IOSApps/LogAppEvent+Music.swift
@@ -3,6 +3,7 @@ import DuetSQL
 import Foundation
 import GertieApp
 import IOSAppsRoute
+import XCore
 
 extension LogAppEvent {
   static func resolveMusicEvent(_ input: Input, in context: Context) async throws -> Output {
@@ -31,16 +32,81 @@ extension LogAppEvent {
 
     ModelIdentifier.alertIfUnknown(input.modelIdentifier)
 
-    if context.env.mode == .prod, input.level > .debug {
-      let search = githubSearch(input.eventId)
-      let detail = input.detail.map { " - \($0)" } ?? ""
-      let name = EventLabel.name(input.app, input.eventId) ?? input.eventId
+    if context.env.mode == .prod,
+       input.level > .debug,
+       await musicEventShouldSlack(input, deviceId: deviceId, in: context) {
       await get(dependency: \.slack).internal(
         input.app.slackChannel,
-        "\(input.app.marketingName) event: \(search) `\(name)`\(detail)",
+        musicEventSlackMessage(input, deviceId: deviceId, in: context),
       )
     }
 
     return .success
   }
 }
+
+private func musicEventShouldSlack(
+  _ input: LogEventRequest,
+  deviceId: IOSDevice.Id?,
+  in context: Context,
+) async -> Bool {
+  switch input.eventId {
+  case musicOnboardingCompleteEventId:
+    await isFirstMusicEvent(input.eventId, deviceId: deviceId, since: nil, in: context)
+  case musicPlaybackFailedEventId:
+    await isFirstMusicEvent(
+      input.eventId,
+      deviceId: deviceId,
+      since: Date(subtractingHours: 1),
+      in: context,
+    )
+  default:
+    true
+  }
+}
+
+private func isFirstMusicEvent(
+  _ eventId: String,
+  deviceId: IOSDevice.Id?,
+  since: Date?,
+  in context: Context,
+) async -> Bool {
+  guard let deviceId else { return false }
+  var query = MusicApp.Event.query()
+    .where(.deviceId == deviceId)
+    .where(.eventId == eventId)
+  if let since {
+    query = query.where(.createdAt > since)
+  }
+  return await (try? query.count(in: context.db)) == 1
+}
+
+private func musicEventSlackMessage(
+  _ input: LogEventRequest,
+  deviceId: IOSDevice.Id?,
+  in context: Context,
+) async -> String {
+  let search = githubSearch(input.eventId)
+  let detail = input.detail.map { " - \($0)" } ?? ""
+  let name = EventLabel.name(input.app, input.eventId) ?? input.eventId
+  let base = "\(input.app.marketingName) event: \(search) `\(name)`\(detail)"
+
+  guard let deviceId else { return base }
+
+  guard let device = try? await context.db.find(deviceId) as IOSDevice,
+        let child = try? await device.child(in: context.db),
+        let parent = try? await child.parent(in: context.db) else {
+    return base
+  }
+
+  let install = AdminLink().slack(
+    to: .musicInstall(deviceId: deviceId.rawValue),
+    text: "see install",
+  )
+  return base
+    + ", parent: \(parent.adminSiteLink(.slack)), child: `\(child.name)`,"
+    + " device: `\(input.modelName)`, \(install)"
+}
+
+private let musicOnboardingCompleteEventId = "8af8b414"
+private let musicPlaybackFailedEventId = "f357b375"

--- a/swift/api/Sources/Api/Services/AdminLink.swift
+++ b/swift/api/Sources/Api/Services/AdminLink.swift
@@ -5,6 +5,7 @@ struct AdminLink {
   enum Path {
     case parent(Parent.Id)
     case iosDeviceEvents(vendorId: UUID)
+    case musicInstall(deviceId: UUID)
     case verify(token: UUID)
 
     var pathComponent: String {
@@ -13,6 +14,8 @@ struct AdminLink {
         "parents/\(id.lowercased)"
       case .iosDeviceEvents(let vendorId):
         "blocker/\(vendorId.lowercased)/events"
+      case .musicInstall(let deviceId):
+        "music/\(deviceId.lowercased)/detail"
       case .verify(let token):
         "verify/\(token.uuidString.lowercased())"
       }

--- a/swift/api/Tests/ApiTests/ApiTests.swift
+++ b/swift/api/Tests/ApiTests/ApiTests.swift
@@ -199,3 +199,11 @@ extension Context {
     )
   }
 }
+
+extension Env {
+  static var prodMode: Self {
+    var env = Env.fromProcess(mode: .testing)
+    env.mode = .prod
+    return env
+  }
+}

--- a/swift/api/Tests/ApiTests/IOSAppsPairResolvers/LogAppEventResolverTests.swift
+++ b/swift/api/Tests/ApiTests/IOSAppsPairResolvers/LogAppEventResolverTests.swift
@@ -1,6 +1,8 @@
+import Dependencies
 import DuetSQL
 import GertieApp
 import IOSAppsRoute
+import XCore
 import XCTest
 import XExpect
 
@@ -71,6 +73,76 @@ final class LogAppEventResolverTests: ApiTestCase, @unchecked Sendable {
       .where(.deviceId == IOSDevice.Id(input.deviceId!))
       .first(in: self.db)
     expect(install.appVersion).toEqual("1.2.3")
+  }
+
+  func testSlacksMusicOnboardingCompleteOnlyOnFirstOccurrence() async throws {
+    let child = try await self.child()
+    let (device, _) = try await self.claimedMusicInstall(for: child)
+
+    try await withDependencies {
+      $0.env = .prodMode
+    } operation: {
+      let input = LogEventRequest(
+        app: .music,
+        eventId: "8af8b414", // "Onboarding setup completed"
+        level: .info,
+        domain: "setup",
+        deviceId: device.id.rawValue,
+        modelIdentifier: "iPhone16,1",
+        appVersion: "1.0.0",
+        iosVersion: "18.5",
+      )
+
+      _ = try await LogAppEvent.resolve(with: input, in: .mock)
+
+      expect(self.sent.slacks).toHaveCount(1)
+      expect(self.sent.slacks[0].message.text).toContain("Onboarding setup completed")
+      expect(self.sent.slacks[0].message.text).toContain(child.name) // enriched w/ identity
+
+      // the app re-emits this on every cold launch of an already set-up device
+      _ = try await LogAppEvent.resolve(with: input, in: .mock)
+      _ = try await LogAppEvent.resolve(with: input, in: .mock)
+
+      expect(self.sent.slacks).toHaveCount(1)
+      let events = try await MusicApp.Event.query()
+        .where(.deviceId == device.id)
+        .where(.eventId == "8af8b414")
+        .all(in: self.db)
+      expect(events).toHaveCount(3) // ...but all 3 are still stored
+    }
+  }
+
+  func testThrottlesMusicPlaybackFailedSlackToOncePerDevicePerHour() async throws {
+    let child = try await self.child()
+    let (device, _) = try await self.claimedMusicInstall(for: child)
+
+    try await withDependencies {
+      $0.env = .prodMode
+    } operation: {
+      let input = LogEventRequest(
+        app: .music,
+        eventId: "f357b375", // "Playback failed"
+        level: .err,
+        domain: "playback",
+        detail: "playbackFailed NSError (MPMusicPlayerControllerErrorDomain error 1.)",
+        deviceId: device.id.rawValue,
+        modelIdentifier: "iPhone16,1",
+        appVersion: "1.0.0",
+        iosVersion: "18.5",
+      )
+
+      for _ in 1 ... 5 { // a burst, as seen in prod
+        _ = try await LogAppEvent.resolve(with: input, in: .mock)
+      }
+
+      expect(self.sent.slacks).toHaveCount(1)
+      expect(self.sent.slacks[0].message.text).toContain(child.name) // enriched w/ identity
+      let events = try await MusicApp.Event.query()
+        .where(.deviceId == device.id)
+        .where(.eventId == "f357b375")
+        .all(in: self.db)
+      expect(events).toHaveCount(5) // ...but all 5 are still stored
+    }
   }
 
   func testLogsPodcastEventAndEnsuresInstall() async throws {

--- a/swift/music/lib-tca/Sources/Setup/MusicSetupFeature.swift
+++ b/swift/music/lib-tca/Sources/Setup/MusicSetupFeature.swift
@@ -12,6 +12,7 @@ struct MusicSetupFeature: Sendable {
     var screen = Screen.checking
     var claimAudience = MusicClaimAudience.parentPartner
     var prefetch = Prefetch.loading
+    var resumedStoredConnection = false
 
     enum Prefetch: Equatable {
       case loading
@@ -90,6 +91,8 @@ struct MusicSetupFeature: Sendable {
         state.screen = .checking
         // a returning user already has a connection; skip onboarding, resolve Apple Music
         if self.keychain.loadConnection() != nil {
+          state.resumedStoredConnection = true
+          log(.debug, .setup, "9cfe15f7")
           return self.checkAppleMusicAuthorization()
         }
         state.screen = .welcome
@@ -290,7 +293,9 @@ struct MusicSetupFeature: Sendable {
       return .cancel(id: CancelID.musicAppStatusPolling)
     }
     state.screen = .ready(childName: childName)
-    log(.info, .setup, "8af8b414")
+    if !state.resumedStoredConnection {
+      log(.info, .setup, "8af8b414")
+    }
     return .merge(
       .cancel(id: CancelID.musicAppStatusPolling),
       .send(.delegate(.completed(childName: childName))),

--- a/swift/music/lib-tca/Tests/LibTCATests/MusicSetupFeatureTests.swift
+++ b/swift/music/lib-tca/Tests/LibTCATests/MusicSetupFeatureTests.swift
@@ -239,22 +239,64 @@ struct MusicSetupFeatureTests {
 
   @Test
   func returningUserSkipsOnboardingToAppleMusic() async {
+    let logged = LockIsolated<[String]>([])
     let keychain = KeychainStore()
     keychain.client.save(connection: .init(token: UUID(1), childId: UUID(2), childName: "Harriet"))
     let store = TestStore(initialState: .init()) {
       MusicSetupFeature()
     } withDependencies: {
+      $0.appEvent.record = { event in logged.withValue { $0.append(event.eventId) } }
       $0.keychain = keychain.client
       $0.musicSetup.authorizationStatus = { .authorized }
       $0.musicSetup.subscriptionStatus = { .canPlayCatalogContent }
     }
 
-    await store.send(.onAppear) // stays on .checking: no welcome, no prefetch
+    await store.send(.onAppear) { // stays on .checking: no welcome, no prefetch
+      $0.resumedStoredConnection = true
+    }
+    #expect(logged.value == ["9cfe15f7"]) // logged at launch, not at ready
     await store.receive(.appleMusicAuthorizationStatusLoaded(.authorized))
     await store.receive(.appleMusicSubscriptionStatusLoaded(.canPlayCatalogContent)) {
       $0.screen = .ready(childName: "Harriet")
     }
     await store.receive(.delegate(.completed(childName: "Harriet")))
+
+    #expect(logged.value == ["9cfe15f7"]) // a relaunch, NOT an onboarding completion
+  }
+
+  @Test
+  func firstTimeSetupCompletionLogsOnboardingComplete() async {
+    let logged = LockIsolated<[String]>([])
+    let keychain = KeychainStore()
+    var state = MusicSetupFeature.State()
+    state.screen = .welcome
+    state.prefetch = .loaded(.claimed(
+      token: UUID(1),
+      childId: UUID(2),
+      childName: "Harriet",
+      entitlement: .active,
+    ))
+    let store = TestStore(initialState: state) {
+      MusicSetupFeature()
+    } withDependencies: {
+      $0.appEvent.record = { event in logged.withValue { $0.append(event.eventId) } }
+      $0.keychain = keychain.client
+      $0.musicSetup.authorizationStatus = { .authorized }
+      $0.musicSetup.subscriptionStatus = { .canPlayCatalogContent }
+    }
+
+    await store.send(.getStartedButtonTapped) {
+      $0.screen = .deviceRecognized(childName: "Harriet")
+    }
+    await store.send(.deviceRecognizedContinueButtonTapped)
+    await store.receive(.appleMusicAuthorizationStatusLoaded(.authorized))
+    await store.receive(.appleMusicSubscriptionStatusLoaded(.canPlayCatalogContent)) {
+      $0.screen = .ready(childName: "Harriet")
+    }
+    await store.receive(.delegate(.completed(childName: "Harriet")))
+
+    #expect(logged.value.contains("8af8b414"))
+    #expect(!logged.value.contains("9cfe15f7"))
   }
 
   @Test

--- a/swift/x-kit/Sources/XCore/Date.swift
+++ b/swift/x-kit/Sources/XCore/Date.swift
@@ -32,6 +32,12 @@ public extension Date {
     let days = DateComponents(day: -numDays)
     self = calendar.date(byAdding: days, to: reference)!
   }
+
+  init(subtractingHours numHours: Int, from reference: Date = Date()) {
+    let calendar = Calendar.current
+    let hours = DateComponents(hour: -numHours)
+    self = calendar.date(byAdding: hours, to: reference)!
+  }
 }
 
 // helpers


### PR DESCRIPTION
- this fixes the fact that we're sending an "onboarding complete" message everytime the app does a normal launch, fixed in the ios client, but also suppressed in the slack logging machinery now
- also, enriches most interesting slacks with account/person info