### PR TITLE
music: throttle trackUnavailable slack alerts + enrich playback diagnostics

### DIFF
--- a/swift/api/Sources/Api/PairQL/IOSApps/LogAppEvent+Music.swift
+++ b/swift/api/Sources/Api/PairQL/IOSApps/LogAppEvent+Music.swift
@@ -53,7 +53,7 @@ private func musicEventShouldSlack(
   switch input.eventId {
   case musicOnboardingCompleteEventId:
     await isFirstMusicEvent(input.eventId, deviceId: deviceId, since: nil, in: context)
-  case musicPlaybackFailedEventId:
+  case musicPlaybackFailedEventId, musicTrackUnavailableEventId:
     await isFirstMusicEvent(
       input.eventId,
       deviceId: deviceId,
@@ -110,3 +110,4 @@ private func musicEventSlackMessage(
 
 private let musicOnboardingCompleteEventId = "8af8b414"
 private let musicPlaybackFailedEventId = "f357b375"
+private let musicTrackUnavailableEventId = "e1423c41"

--- a/swift/music/lib-tca/Sources/Deps/PlaybackClient.swift
+++ b/swift/music/lib-tca/Sources/Deps/PlaybackClient.swift
@@ -350,13 +350,13 @@ extension PlaybackClient {
       )
       do {
         guard let song = try await request.response().items.first else {
-          throw PlaybackClientError.trackUnavailable
+          throw await self.trackUnavailable(for: [songID.rawValue])
         }
         let detailedSong = try await song.with(.albums)
         return detailedSong.albums?.map { ApprovedAlbum.ID($0.id.rawValue) } ?? []
       } catch let error as MusicDataRequest.Error {
         if error.status == 404 {
-          throw PlaybackClientError.trackUnavailable
+          throw await self.trackUnavailable(for: [songID.rawValue])
         }
         throw PlaybackClientError.catalogLookupFailed(.init(error))
       } catch let error as MusicTokenRequestError {
@@ -871,7 +871,7 @@ extension PlaybackClient {
             songsByID[songID.rawValue].map { (index, $0) }
           }
         guard !availableSongs.isEmpty else {
-          throw PlaybackClientError.trackUnavailable
+          throw await self.trackUnavailable(for: checkpoint.songIDs.map(\.rawValue))
         }
         let exactCurrentIndex = availableSongs.firstIndex {
           $0.originalIndex == checkpoint.currentIndex
@@ -886,7 +886,7 @@ extension PlaybackClient {
         )
       } catch let error as MusicDataRequest.Error {
         if error.status == 404 {
-          throw PlaybackClientError.trackUnavailable
+          throw await self.trackUnavailable(for: checkpoint.songIDs.map(\.rawValue))
         }
         throw PlaybackClientError.catalogLookupFailed(.init(error))
       } catch let error as MusicTokenRequestError {
@@ -913,15 +913,17 @@ extension PlaybackClient {
         let response = try await request.response()
         let songsByID = Dictionary(uniqueKeysWithValues: response.items
           .map { ($0.id.rawValue, $0) })
-        return try items.map { item in
+        var songs: [Song] = []
+        for item in items {
           guard let song = songsByID[item.id.rawValue] else {
-            throw PlaybackClientError.trackUnavailable
+            throw await self.trackUnavailable(for: [item.id.rawValue])
           }
-          return song
+          songs.append(song)
         }
+        return songs
       } catch let error as MusicDataRequest.Error {
         if error.status == 404 {
-          throw PlaybackClientError.trackUnavailable
+          throw await self.trackUnavailable(for: items.map(\.id.rawValue))
         }
         throw PlaybackClientError.catalogLookupFailed(.init(error))
       } catch let error as MusicTokenRequestError {
@@ -936,6 +938,18 @@ extension PlaybackClient {
       } catch {
         throw PlaybackClientError.catalogLookupFailed(.init(unexpected: error))
       }
+    }
+
+    private static func trackUnavailable(for trackIDs: [String]) async -> PlaybackClientError {
+      let storefront = await (try? MusicDataRequest.currentCountryCode) ?? "unknown"
+      let trackDetail = if trackIDs.count == 1, let trackID = trackIDs.first {
+        "trackId=\(trackID)"
+      } else {
+        "trackIds=\(trackIDs.joined(separator: ","))"
+      }
+      return .trackUnavailable(
+        PlaybackDiagnostic(summary: "\(trackDetail) storefront=\(storefront)"),
+      )
     }
   #endif
 }
@@ -1328,19 +1342,19 @@ enum PlaybackClientError: Error, Equatable, Sendable {
   case musicAccessRestricted
   case playbackFailed(PlaybackDiagnostic?)
   case privacyAcknowledgementRequired
-  case trackUnavailable
+  case trackUnavailable(PlaybackDiagnostic?)
 
   var diagnostic: PlaybackDiagnostic? {
     switch self {
     case .appleMusicSignInRequired(let diagnostic),
          .catalogLookupFailed(let diagnostic),
-         .playbackFailed(let diagnostic):
+         .playbackFailed(let diagnostic),
+         .trackUnavailable(let diagnostic):
       diagnostic
     case .appleMusicSubscriptionRequired,
          .musicAccessDenied,
          .musicAccessRestricted,
-         .privacyAcknowledgementRequired,
-         .trackUnavailable:
+         .privacyAcknowledgementRequired:
       nil
     }
   }


### PR DESCRIPTION
## Why

A GB user's kid generated ~25 identical `Playback: track unavailable` (`e1423c41`) lines in the `#music` Slack channel in about an hour, and the events carried no context — we couldn't tell which song failed or what storefront the device was actually on. Two small, independent logging fixes.

## Changes

**1. Throttle the Slack noise (API)**
`LogAppEvent+Music.swift` fans every music event above `.debug` into Slack, throttling only onboarding-complete and playbackFailed. `trackUnavailable` fell through `default: true`, so it posted on every retry. Now it's throttled to **1 per hour per device** (same bucket as playbackFailed). The DB event row is still always written; only the Slack post is gated.

**2. Enrich the diagnostics (music app)**
`PlaybackClientError.trackUnavailable` previously carried no `PlaybackDiagnostic`, so the logged detail was the bare string `trackUnavailable`. It now carries the failing **track id(s)** and the device's **real Apple Music storefront** (MusicKit `currentCountryCode`, falling back to `unknown`), threaded through all six throw sites. Event detail now reads e.g.:

```
trackUnavailable trackId=528437514 storefront=gb
```

That storefront value is the key missing datum — the device *locale* is knowable from other apps, but the Apple Music storefront (set by the signed-in Apple ID) is not, and it's what actually determines catalog availability.

## Out of scope
The underlying data bug — nothing sets a child's `apple_music_storefront` from the device, so it's the `us` default for ~1263/1264 kids — is a separate product fix. This PR is just logging.

## Tests
- API: throttle coverage in `LogAppEventResolverTests`
- Music: log-detail coverage in `PlaybackFeatureTests`
- `just api-test`, `just music test`, `just swift lint-swift` green